### PR TITLE
Format imports with module granularity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,5 +42,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # We use an unstable rustmft feature and we thus need the
+      # nightly channel to enforce the formatting.
+      - name: Setup Rust nightly
+        run: rustup default nightly
+
+      - name: Install rustfmt
+        run: rustup component add rustfmt
+
       - name: Check Formatting
         uses: dprint/check@v2.2

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+# https://github.com/rust-lang/rustfmt/issues/4991
+imports_granularity = "Module"


### PR DESCRIPTION
This is an unstable `rustfmt` option, so we switch to the nightly channel to make it take effect.