### PR TITLE
Update `polib` dependency to version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.68"
 mdbook = "0.4.25"
-polib = "0.1.0"
+polib = "0.2.0"
 pulldown-cmark = { version = "0.9.2", default-features = false }
 semver = "1.0.16"
 serde_json = "1.0.91"

--- a/src/bin/mdbook-gettext.rs
+++ b/src/bin/mdbook-gettext.rs
@@ -50,11 +50,10 @@ fn translate(text: &str, catalog: &Catalog) -> String {
         // Insert the translated text
         let msg_text = msg.text(text);
         let translated = catalog
-            .find_message(msg_text)
-            .filter(|msg| !msg.flags.contains("fuzzy"))
-            .and_then(|msg| msg.get_msgstr().ok())
+            .find_message(None, msg_text, None)
+            .filter(|msg| !msg.flags().is_fuzzy())
+            .and_then(|msg| msg.msgstr().ok())
             .filter(|msgstr| !msgstr.is_empty())
-            .map(|msgstr| msgstr.as_str())
             .unwrap_or(msg_text);
         output.push_str(translated);
         consumed = span.end;
@@ -139,12 +138,16 @@ fn main() -> anyhow::Result<()> {
 mod tests {
     use super::*;
     use polib::message::Message;
+    use polib::metadata::CatalogMetadata;
 
     fn create_catalog(translations: &[(&str, &str)]) -> Catalog {
-        let mut catalog = Catalog::new();
+        let mut catalog = Catalog::new(CatalogMetadata::new());
         for (msgid, msgstr) in translations {
-            let message = Message::new_singular("", "", "", "", msgid, msgstr);
-            catalog.add_message(message);
+            let message = Message::build_singular()
+                .with_msgid(String::from(*msgid))
+                .with_msgstr(String::from(*msgstr))
+                .done();
+            catalog.append_or_update(message);
         }
         catalog
     }

--- a/src/bin/mdbook-xgettext.rs
+++ b/src/bin/mdbook-xgettext.rs
@@ -25,42 +25,40 @@ use mdbook::BookItem;
 use mdbook_i18n_helpers::extract_msgs;
 use polib::catalog::Catalog;
 use polib::message::Message;
+use polib::metadata::CatalogMetadata;
 use std::{fs, io};
 
 fn add_message(catalog: &mut Catalog, msgid: &str, source: &str) {
-    let sources = match catalog.find_message(msgid) {
-        Some(msg) => format!("{}\n{}", msg.source, source),
+    let sources = match catalog.find_message(None, msgid, None) {
+        Some(msg) => format!("{}\n{}", msg.source(), source),
         None => String::from(source),
     };
-    let message = Message::new_singular("", &sources, "", "", msgid, "");
-
-    // Carefully update the existing message or add a new one. It's an
-    // error to create a catalog with duplicate msgids.
-    match catalog.find_message_index(msgid) {
-        Some(&idx) => catalog.update_message_by_index(idx, message).unwrap(),
-        None => catalog.add_message(message),
-    }
+    let message = Message::build_singular()
+        .with_source(sources)
+        .with_msgid(String::from(msgid))
+        .done();
+    catalog.append_or_update(message);
 }
 
 fn create_catalog(ctx: &RenderContext) -> anyhow::Result<Catalog> {
-    let mut catalog = Catalog::new();
+    let mut metadata = CatalogMetadata::new();
     if let Some(title) = &ctx.config.book.title {
-        catalog.metadata.project_id_version = String::from(title);
+        metadata.project_id_version = String::from(title);
     }
     if let Some(lang) = &ctx.config.book.language {
-        catalog.metadata.language = String::from(lang);
+        metadata.language = String::from(lang);
     }
-    catalog.metadata.mime_version = String::from("1.0");
-    catalog.metadata.content_type = String::from("text/plain; charset=UTF-8");
-    catalog.metadata.content_transfer_encoding = String::from("8bit");
-
-    let summary_path = ctx.config.book.src.join("SUMMARY.md");
-    let summary = std::fs::read_to_string(ctx.root.join(&summary_path))?;
+    metadata.mime_version = String::from("1.0");
+    metadata.content_type = String::from("text/plain; charset=UTF-8");
+    metadata.content_transfer_encoding = String::from("8bit");
+    let mut catalog = Catalog::new(metadata);
 
     // First, add all chapter names and part titles from SUMMARY.md.
     // The book items are in order of the summary, so we can assign
     // correct line numbers for duplicate lines by tracking the index
     // of our last search.
+    let summary_path = ctx.config.book.src.join("SUMMARY.md");
+    let summary = std::fs::read_to_string(ctx.root.join(&summary_path))?;
     let mut last_idx = 0;
     for item in ctx.book.iter() {
         let line = match item {
@@ -113,10 +111,6 @@ fn main() -> anyhow::Result<()> {
     fs::create_dir_all(&ctx.destination)
         .with_context(|| format!("Could not create {}", ctx.destination.display()))?;
     let output_path = ctx.destination.join(path);
-    if output_path.exists() {
-        fs::remove_file(&output_path)
-            .with_context(|| format!("Removing {}", output_path.display()))?
-    }
     let catalog = create_catalog(&ctx).context("Extracting messages")?;
     polib::po_file::write(&catalog, &output_path)
         .with_context(|| format!("Writing messages to {}", output_path.display()))?;


### PR DESCRIPTION
The API changed a little from version 0.1.0.

The new release includes https://github.com/BrettDong/polib/pull/1, which means we can simplify the code that writes a new PO file.