### PR TITLE
Link back to `mdbook` i18n issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 The plugins here makes it easy to translate documentation written in
 [`mdbook`](https://github.com/rust-lang/mdBook/) into multiple languages.
+Support for translations is a
+[long-stading feature request for `mdbook`](https://github.com/rust-lang/mdBook/issues/5).
 
 They've been used successfully to translate [Comprehensive Rust 🦀].
 


### PR DESCRIPTION
The upstream issue (https://github.com/rust-lang/mdBook/issues/5) has been open since 2015.