### PR TITLE
Extract code blocks as self-contained values

### DIFF
--- a/src/bin/mdbook-gettext.rs
+++ b/src/bin/mdbook-gettext.rs
@@ -233,8 +233,12 @@ mod tests {
     #[test]
     fn test_translate_code_block() {
         let catalog = create_catalog(&[(
-            "fn foo() {\n\n    let x = 10;\n\n}\n",
-            "fn FOO() {\n\n    let X = 10;\n\n}\n",
+            "```rust,editable\n\
+             fn foo() {\n\n    let x = 10;\n\n}\n\
+             ```",
+            "```rust,editable\n\
+             fn FOO() {\n\n    let X = 10;\n\n}\n\
+             ```",
         )]);
         assert_eq!(
             translate(


### PR DESCRIPTION
Before, `extract_messages` would turn a code block into text indistinguishable from a normal paragraph. This is bad since we would like `extract_messages` to be idempotent since that makes it easier to reason about normalization of the PO files.