### PR TITLE
Fix table rendering

### DIFF
--- a/src/bin/mdbook-gettext.rs
+++ b/src/bin/mdbook-gettext.rs
@@ -232,4 +232,30 @@ mod tests {
              Text after.",
         );
     }
+
+    #[test]
+    fn test_translate_table() {
+        let catalog = create_catalog(&[
+            ("Types", "TYPES"),
+            ("Literals", "LITERALS"),
+            ("Arrays", "ARRAYS"),
+            ("Tuples", "TUPLES"),
+        ]);
+        // The alignment is lost when we generate new Markdown.
+        assert_eq!(
+            translate(
+                "\
+                |        | Types       | Literals        |\n\
+                |--------|-------------|-----------------|\n\
+                | Arrays | `[T; N]`    | `[20, 30, 40]`  |\n\
+                | Tuples | `()`, ...   | `()`, `('x',)`  |",
+                &catalog
+            ),
+            "\
+            ||TYPES|LITERALS|\n\
+            |--|-----|--------|\n\
+            |ARRAYS|`[T; N]`|`[20, 30, 40]`|\n\
+            |TUPLES|`()`, ...|`()`, `('x',)`|",
+        );
+    }
 }


### PR DESCRIPTION
When extracting events from a line of text, we get

    &[
        (1, Event::Start(Tag::Paragraph)),
        (1, Event::Text("A line of text".into())),
        (1, Event::End(Tag::Paragraph)),
    ],

This is problematic since the `Text` event has been wrapped in a paragraph. This is mostly harmless in regular text, but it destroys the formatting of tables since they cannot contain block-level events such as paragraphs.

This is now fixed by more carefully trimming the events we inject when translating.