### PR TITLE
Add support for skipping the next translation group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,7 @@ dependencies = [
  "pretty_assertions",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
+ "regex",
  "semver",
  "serde_json",
  "tempfile",
@@ -600,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -612,9 +613,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -623,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ mdbook = { version = "0.4.25", default-features = false }
 polib = "0.2.0"
 pulldown-cmark = { version = "0.9.2", default-features = false }
 pulldown-cmark-to-cmark = "10.0.4"
+regex = "1.9.4"
 semver = "1.0.16"
 serde_json = "1.0.91"
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -182,6 +182,34 @@ Please see the [`publish.yml`] workflow in the Comprehensive Rust 🦀 repositor
 
 [`publish.yml`]: https://github.com/google/comprehensive-rust/blob/main/.github/workflows/publish.yml
 
+## Marking Sections to be Skipped for Translation
+
+A block can be marked to be skipped for translation by prepending a special HTML
+comment `<!--- mdbook-xgettext:skip -->` to it.
+
+For example:
+
+````markdown
+The following code block should not be translated.
+
+<!--- mdbook-xgettext:skip -->
+
+```
+fn hello() {
+  println!("Hello world!");
+}
+```
+
+Itemized list:
+
+- A should be translated.
+
+<!--- mdbook-xgettext:skip -->
+
+- B should be skipped.
+- C should be translated.
+````
+
 ## Normalizing Existing PO Files
 
 When mdbook-i18n-helpers change, the generated PO files change as well. This can


### PR DESCRIPTION
This is the beginning of support for handling special comments for translation, https://github.com/google/mdbook-i18n-helpers/issues/63

This adds support for adding a comment of the form: `<!-- mdbook-xgettext: skip -->`.  This will cause the system to skip the next message group that would otherwise be translated.

It adds a dependency to the regex crate to match for the comment skip pattern.