### PR TITLE
Automatically ignore codeblocks that don't have lit-strings or line comments.

### DIFF
--- a/src/bin/mdbook-gettext.rs
+++ b/src/bin/mdbook-gettext.rs
@@ -205,10 +205,10 @@ mod tests {
     fn test_translate_code_block() {
         let catalog = create_catalog(&[(
             "```rust,editable\n\
-             fn foo() {\n\n    let x = 10;\n\n}\n\
+             fn foo() {\n\n    let x = \"hello\";\n\n}\n\
              ```",
             "```rust,editable\n\
-             fn FOO() {\n\n    let X = 10;\n\n}\n\
+             fn FOO() {\n\n    let X = \"guten tag\";\n\n}\n\
              ```",
         )]);
         assert_eq!(
@@ -217,7 +217,7 @@ mod tests {
                  \n\
                  \n\
                  ```rust,editable\n\
-                 fn foo() {\n\n    let x = 10;\n\n}\n\
+                 fn foo() {\n\n    let x = \"hello\";\n\n}\n\
                  ```\n\
                  \n\
                  Text after.\n",
@@ -226,7 +226,7 @@ mod tests {
             "Text before.\n\
              \n\
              ```rust,editable\n\
-             fn FOO() {\n\n    let X = 10;\n\n}\n\
+             fn FOO() {\n\n    let X = \"guten tag\";\n\n}\n\
              ```\n\
              \n\
              Text after.",

--- a/src/bin/mdbook-i18n-normalize.rs
+++ b/src/bin/mdbook-i18n-normalize.rs
@@ -490,11 +490,13 @@ mod tests {
     fn test_normalize_code_blocks() {
         let catalog = create_catalog(&[(
             "```rust,editable\n\
+             // Example\n\
              foo\n\
              \n\
              * bar\n\
              ```",
             "```rust,editable\n\
+             // Beispiel\n\
              FOO\n\
              \n\
              * BAR\n\
@@ -504,11 +506,13 @@ mod tests {
             catalog,
             &[exact(
                 "```rust,editable\n\
+                 // Example\n\
                  foo\n\
                  \n\
                  * bar\n\
                  ```",
                 "```rust,editable\n\
+                 // Beispiel\n\
                  FOO\n\
                  \n\
                  * BAR\n\


### PR DESCRIPTION
This tries to automatically omit codeblocks that don't have what looks like translatable content.  For the moment, we check whether the body of a codeblock contains a "\"" or "//" substring, which is a heuristic for checking for literal strings or line comments.