### PR TITLE
Split POT file depending on specified depth

### DIFF
--- a/fuzz/fuzz_targets/xgettext.rs
+++ b/fuzz/fuzz_targets/xgettext.rs
@@ -6,7 +6,7 @@ use std::str::FromStr;
 use libfuzzer_sys::fuzz_target;
 use mdbook::renderer::RenderContext;
 use mdbook::Config;
-use mdbook_i18n_helpers::xgettext::create_catalog;
+use mdbook_i18n_helpers::xgettext::create_catalogs;
 use mdbook_i18n_helpers_fuzz::{create_book, BookItem};
 
 fuzz_target!(|inputs: (&str, Vec<BookItem>)| {
@@ -16,5 +16,5 @@ fuzz_target!(|inputs: (&str, Vec<BookItem>)| {
 
     let ctx = RenderContext::new(PathBuf::new(), book, Config::from_str("").unwrap(), "");
 
-    let _ = create_catalog(&ctx, |_| Ok(summary.to_string()));
+    let _ = create_catalogs(&ctx, |_| Ok(summary.to_string()));
 });

--- a/i18n-helpers/USAGE.md
+++ b/i18n-helpers/USAGE.md
@@ -77,11 +77,21 @@ To extract the original text and generate a `messages.pot` file, you run
 `mdbook` with the `mdbook-xgettext` renderer:
 
 ```shell
-MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' \
+MDBOOK_OUTPUT='{"xgettext": {}}' \
   mdbook build -d po
 ```
 
 You will find the generated POT file as `po/messages.pot`.
+
+To extract the text into smaller `.pot` files based on the text's Markdown
+outline, use the `depth` parameter. For a `depth` of `1`, the `.pot` lines will
+be separated into a file for each section or chapter title. Use greater values
+to split the `.pot` file further.
+
+```shell
+MDBOOK_OUTPUT='{"xgettext": {"depth": "1"}}' \
+  mdbook build -d po/messages
+```
 
 ### Initialize a New Translation
 

--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -14,12 +14,13 @@
 
 //! This file contains main logic used by the binary `mdbook-xgettext`.
 
+use std::collections::HashMap;
 use std::{io, path};
 
 use super::{extract_events, extract_messages, reconstruct_markdown, wrap_sources};
 use anyhow::{anyhow, Context};
 use mdbook::renderer::RenderContext;
-use mdbook::BookItem;
+use mdbook::{book, BookItem};
 use polib::catalog::Catalog;
 use polib::message::{Message, MessageMutView, MessageView};
 use polib::metadata::CatalogMetadata;
@@ -87,16 +88,8 @@ fn dedup_sources(catalog: &mut Catalog) {
     }
 }
 
-/// Build catalog from RenderContext
-///
-/// # Arguments
-
-/// * `ctx` - RenderContext from mdbook library
-/// * `summary_reader` - A closure which reads summary at given path
-pub fn create_catalog<F>(ctx: &RenderContext, summary_reader: F) -> anyhow::Result<Catalog>
-where
-    F: Fn(path::PathBuf) -> io::Result<String>,
-{
+/// Build CatalogMetadata from RenderContext
+fn generate_catalog_metadata(ctx: &RenderContext) -> CatalogMetadata {
     let mut metadata = CatalogMetadata::new();
     if let Some(title) = &ctx.config.book.title {
         metadata.project_id_version = String::from(title);
@@ -109,6 +102,21 @@ where
     metadata.mime_version = String::from("1.0");
     metadata.content_type = String::from("text/plain; charset=UTF-8");
     metadata.content_transfer_encoding = String::from("8bit");
+    metadata
+}
+
+/// Build catalog from RenderContext
+///
+/// The `summary_reader` is a closure which should return the
+/// `SUMMARY.md` found at the given path.
+pub fn create_catalogs<F>(
+    ctx: &RenderContext,
+    summary_reader: F,
+) -> anyhow::Result<HashMap<path::PathBuf, Catalog>>
+where
+    F: Fn(path::PathBuf) -> io::Result<String>,
+{
+    let metadata = generate_catalog_metadata(ctx);
     let mut catalog = Catalog::new(metadata);
 
     // The line number granularity: we default to 1, but it can be
@@ -147,24 +155,181 @@ where
         );
     }
 
+    let mut catalogs = HashMap::new();
+
+    // The depth on which to split the output file. The default is to
+    // include all messages into a single POT file (depth == 0).
+    // Greater values will split POT files, digging into the
+    // sub-chapters within each chapter.
+    let depth = match ctx
+        .config
+        .get_renderer("xgettext")
+        .and_then(|cfg| cfg.get("depth"))
+    {
+        None => 0,
+        Some(value) => value
+            .as_integer()
+            .and_then(|i| (i >= 0).then_some(i as usize))
+            .ok_or_else(|| anyhow!("Expected an unsigned integer for output.xgettext.depth"))?,
+    };
+
+    // The catalog from the summary data will exist in the single pot
+    // file for a depth of 0, will exist in a top-level separate
+    // `summary.pot` file for a depth of 1, or exist within in a
+    // `summary.pot` file within the default directory for chapters
+    // without a corresponding part title.
+    let mut current_top_level = "summary".to_owned();
+    let mut summary_destination = match depth {
+        0 => path::PathBuf::from("messages"),
+        1 => path::PathBuf::from("summary"),
+        _ => path::PathBuf::from(&current_top_level).join("summary"),
+    };
+    let _: bool = summary_destination.set_extension("pot");
+    catalogs.insert(summary_destination, catalog);
+
     // Next, we add the chapter contents.
-    for item in ctx.book.iter() {
-        if let BookItem::Chapter(chapter) = item {
+    for item in &ctx.book.sections {
+        if let BookItem::PartTitle(title) = item {
+            // Iterating through the book in section-order, the
+            // PartTitle represents the 'section' that each chapter
+            // exists within.
+            current_top_level = slug(title);
+        } else if let BookItem::Chapter(chapter) = item {
             let path = match &chapter.path {
                 Some(path) => ctx.config.book.src.join(path),
                 None => continue,
             };
+            let directory = match depth {
+                0 => path::PathBuf::from("messages"),
+                1 => path::PathBuf::from(current_top_level.clone()),
+                // The current chapter is already at depth 2, so
+                // append the chapter's name for depths greater than
+                // 1.
+                _ => path::PathBuf::from(current_top_level.clone()).join(slug(&chapter.name)),
+            };
+
+            // Add the (destination, catalog) to the map if it doesn't
+            // yet exist, so messages can be appended to the catalog.
+            let mut destination = directory.clone();
+            let _: bool = destination.set_extension("pot");
+            let catalog = catalogs
+                .entry(destination.clone())
+                .or_insert_with(|| Catalog::new(generate_catalog_metadata(ctx)));
+
             for (lineno, extracted) in extract_messages(&chapter.content) {
                 let msgid = extracted.message;
                 let source = build_source(&path, lineno, granularity);
-                add_message(&mut catalog, &msgid, &source, &extracted.comment);
+                add_message(catalog, &strip_link(&msgid), &source, &extracted.comment);
+            }
+
+            // Add the contents for all of the sub-chapters within the
+            // current chapter.
+            for Chapter {
+                content,
+                source,
+                mut destination,
+            } in get_subcontent_for_chapter(chapter, directory, depth, 2)
+            {
+                let _: bool = destination.set_extension("pot");
+                let catalog = catalogs
+                    .entry(destination.clone())
+                    .or_insert_with(|| Catalog::new(generate_catalog_metadata(ctx)));
+
+                let source = ctx.config.book.src.join(&source);
+                for (lineno, extracted) in extract_messages(&content) {
+                    let msgid = extracted.message;
+                    let source = format!("{}:{}", source.display(), lineno);
+                    add_message(catalog, &strip_link(&msgid), &source, &extracted.comment);
+                }
             }
         }
     }
+    catalogs
+        .iter_mut()
+        .for_each(|(_key, catalog)| dedup_sources(catalog));
+    Ok(catalogs)
+}
 
-    dedup_sources(&mut catalog);
+/// A view into the relevant template information held by
+/// `mdbook::book::Chapter` and a location to store the exported polib
+/// messages.
+struct Chapter {
+    /// The chapter's content.
+    content: String,
+    /// The file where the content is sourced.
+    source: path::PathBuf,
+    /// The output destination for the polib template.
+    destination: path::PathBuf,
+}
 
-    Ok(catalog)
+// A recursive function to crawl a chapter's sub-items and get the
+// relevant info to produce a set of po template files.
+fn get_subcontent_for_chapter(
+    c: &book::Chapter,
+    provided_file_path: path::PathBuf,
+    provided_depth: usize,
+    depth: usize,
+) -> Vec<Chapter> {
+    if c.sub_items.is_empty() {
+        return Vec::new();
+    };
+
+    // Iterate through sub-chapters and pull the chapter content,
+    // path, and destination to store the template.
+    c.sub_items
+        .iter()
+        .filter_map(|item| {
+            let BookItem::Chapter(chapter) = item else {
+                return None;
+            };
+            let (chapter_info, new_path) = match &chapter.path {
+                Some(chapter_path) => {
+                    // Append the chapter's name to the template's
+                    // destination when the depth has not surpassed
+                    // the provided value.
+                    let destination = if depth < provided_depth {
+                        provided_file_path.join(slug(&chapter.name))
+                    } else {
+                        provided_file_path.clone()
+                    };
+
+                    let info = Chapter {
+                        content: chapter.content.clone(),
+                        source: chapter_path.clone(),
+                        destination: destination.clone(),
+                    };
+                    (Some(info), destination)
+                }
+                None => (None, provided_file_path.clone()),
+            };
+
+            // Recursively call to get sub-chapter contents.
+            Some(chapter_info.into_iter().chain(get_subcontent_for_chapter(
+                chapter,
+                new_path,
+                provided_depth,
+                depth + 1,
+            )))
+        })
+        .flatten()
+        .collect()
+}
+
+// Trim a string slice to only contain alphanumeric characters and
+// dashes.
+fn slug(title: &str) -> String {
+    // Specially handle "C++" to format it as "cpp" instead of "c".
+    let title = title.to_lowercase().replace("c++", "cpp");
+    title
+        .split_whitespace()
+        .map(|word| {
+            word.chars()
+                .filter(|&ch| ch == '-' || ch.is_ascii_alphanumeric())
+                .collect::<String>()
+        })
+        .filter(|word| !word.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 #[cfg(test)]
@@ -180,14 +345,29 @@ mod tests {
         std::fs::create_dir(tmpdir.path().join("src"))
             .context("Could not create src/ directory")?;
 
+        // Dynamically create the directories for the listed files.
+        // Write the contents to the file in the specified directory.
         for (path, contents) in files {
-            std::fs::write(tmpdir.path().join(path), contents)
-                .with_context(|| format!("Could not write {path}"))?;
+            let file_path = tmpdir.path().join(path);
+            let directory_path = file_path
+                .parent()
+                .context("File path unexpectedly ended in a root or prefix")?;
+
+            std::fs::create_dir_all(directory_path).context(format!(
+                "Could not create directory {}",
+                directory_path.display()
+            ))?;
+            std::fs::write(file_path.clone(), contents)
+                .with_context(|| format!("Could not write {}", file_path.display()))?;
         }
 
         let mdbook = MDBook::load(tmpdir.path()).context("Could not load book")?;
         let ctx = RenderContext::new(mdbook.root, mdbook.book, mdbook.config, "dest");
         Ok((ctx, tmpdir))
+    }
+
+    fn default_template_file() -> path::PathBuf {
+        path::PathBuf::from("messages.pot")
     }
 
     #[test]
@@ -241,7 +421,8 @@ mod tests {
         let (ctx, _tmp) =
             create_render_context(&[("book.toml", "[book]"), ("src/SUMMARY.md", "")])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string).unwrap();
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string).unwrap();
+        let catalog = &catalogs[&default_template_file()];
         assert_eq!(catalog.metadata.project_id_version, "");
         assert!(!catalog.metadata.pot_creation_date.is_empty());
         assert!(catalog.metadata.po_revision_date.is_empty());
@@ -264,7 +445,10 @@ mod tests {
             ("src/SUMMARY.md", ""),
         ])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string).unwrap();
+        // Using a depth of 0 to include all messages in a single
+        // template file.
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
         assert_eq!(catalog.metadata.project_id_version, "My Translatable Book");
         assert_eq!(catalog.metadata.language, "fr");
         Ok(())
@@ -299,7 +483,8 @@ mod tests {
             ("src/suffix.md", ""),
         ])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string)?;
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
         assert_eq!(
             catalog
                 .messages()
@@ -319,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    fn test_create_catalog() -> anyhow::Result<()> {
+    fn test_create_catalogs() -> anyhow::Result<()> {
         let (ctx, _tmp) = create_render_context(&[
             ("book.toml", "[book]"),
             ("src/SUMMARY.md", "- [The *Foo* Chapter](foo.md)"),
@@ -332,7 +517,8 @@ mod tests {
             ),
         ])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string)?;
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
 
         for msg in catalog.messages() {
             assert!(!msg.is_translated());
@@ -366,7 +552,8 @@ mod tests {
             ),
         ])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string)?;
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
         assert_eq!(
             catalog
                 .messages()
@@ -401,7 +588,8 @@ mod tests {
             ),
         ])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string)?;
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
         assert_eq!(
             catalog
                 .messages()
@@ -439,7 +627,8 @@ mod tests {
             ),
         ])?;
 
-        let catalog = create_catalog(&ctx, std::fs::read_to_string)?;
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
         assert_eq!(
             catalog
                 .messages()
@@ -450,6 +639,436 @@ mod tests {
                 ("src/foo.md:1 src/foo.md:3", "Bar"),
             ]
         );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_catalog_nested_directories() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            ("book.toml", "[book]"),
+            (
+                "src/SUMMARY.md",
+                "- [The Foo Chapter](foo.md)\n\
+                \t- [The Bar Section](foo/bar.md)\n\
+                \t\t- [The Baz Subsection](foo/bar/baz.md)",
+            ),
+            (
+                "src/foo.md",
+                "# How to Foo\n\
+                 \n\
+                 The first paragraph about Foo.\n",
+            ),
+            (
+                "src/foo/bar.md",
+                "# How to Bar\n\
+                 \n\
+                 The first paragraph about Bar.\n",
+            ),
+            (
+                "src/foo/bar/baz.md",
+                "# How to Baz\n\
+                 \n\
+                 The first paragraph about Baz.\n",
+            ),
+        ])?;
+
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+        let catalog = &catalogs[&default_template_file()];
+
+        for msg in catalog.messages() {
+            assert!(!msg.is_translated());
+        }
+
+        let expected_message_tuples = vec![
+            ("src/SUMMARY.md:1", "The Foo Chapter"),
+            ("src/SUMMARY.md:2", "The Bar Section"),
+            ("src/SUMMARY.md:3", "The Baz Subsection"),
+            ("src/foo.md:1", "How to Foo"),
+            ("src/foo.md:3", "The first paragraph about Foo."),
+            ("src/foo/bar.md:1", "How to Bar"),
+            ("src/foo/bar.md:3", "The first paragraph about Bar."),
+            ("src/foo/bar/baz.md:1", "How to Baz"),
+            ("src/foo/bar/baz.md:3", "The first paragraph about Baz."),
+        ];
+
+        let message_tuples = catalog
+            .messages()
+            .map(|msg| (msg.source(), msg.msgid()))
+            .collect::<Vec<(&str, &str)>>();
+
+        assert_eq!(expected_message_tuples, message_tuples);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_catalog_nested_directories_depth_1() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            (
+                "book.toml",
+                "[book]\n\
+                 [output.xgettext]\n\
+                 depth = 1",
+            ),
+            (
+                "src/SUMMARY.md",
+                "# Summary\n\n\
+                 - [Intro](index.md)\n\
+                 # Foo\n\n\
+                 - [The Foo Chapter](foo.md)\n\
+                 \t- [The Bar Section](foo/bar.md)\n\
+                 \t\t- [The Baz Subsection](foo/bar/baz.md)\n\
+                 - [Foo Exercises](exercises/foo.md)",
+            ),
+            ("src/index.md", "# Intro to X"),
+            ("src/foo.md", "# How to Foo"),
+            ("src/foo/bar.md", "# How to Bar"),
+            ("src/foo/bar/baz.md", "# How to Baz"),
+            ("src/exercises/foo.md", "# Exercises on Foo"),
+        ])?;
+
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+
+        let expected_message_tuples = HashMap::from([
+            (
+                path::PathBuf::from("summary.pot"),
+                vec![
+                    "src/SUMMARY.md:1",
+                    "src/SUMMARY.md:3",
+                    "src/SUMMARY.md:4",
+                    "src/SUMMARY.md:6",
+                    "src/SUMMARY.md:7",
+                    "src/SUMMARY.md:8",
+                    "src/SUMMARY.md:9",
+                    "src/index.md:1",
+                ],
+            ),
+            (
+                path::PathBuf::from("foo.pot"),
+                vec![
+                    "src/foo.md:1",
+                    "src/foo/bar.md:1",
+                    "src/foo/bar/baz.md:1",
+                    "src/exercises/foo.md:1",
+                ],
+            ),
+        ]);
+
+        assert_eq!(expected_message_tuples.keys().len(), catalogs.len());
+        for (file_path, catalog) in catalogs {
+            let expected_msgids = &expected_message_tuples[&file_path];
+            assert_eq!(
+                &catalog
+                    .messages()
+                    .map(|msg| msg.source())
+                    .collect::<Vec<_>>(),
+                expected_msgids
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_catalog_nested_directories_depth_2() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            (
+                "book.toml",
+                "[book]\n\
+                 [output.xgettext]\n\
+                 depth = 2",
+            ),
+            (
+                "src/SUMMARY.md",
+                "# Summary\n\n\
+                 - [Intro](index.md)\n\
+                 # Foo\n\n\
+                 - [The Foo Chapter](foo.md)\n\
+                 \t- [The Bar Section](foo/bar.md)\n\
+                 \t\t- [The Baz Subsection](foo/bar/baz.md)\n\
+                 - [Foo Exercises](exercises/foo.md)",
+            ),
+            ("src/index.md", "# Intro to X"),
+            ("src/foo.md", "# How to Foo"),
+            ("src/foo/bar.md", "# How to Bar"),
+            ("src/foo/bar/baz.md", "# How to Baz"),
+            ("src/exercises/foo.md", "# Exercises on Foo"),
+        ])?;
+
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+
+        let expected_message_tuples = HashMap::from([
+            (
+                path::PathBuf::from("summary/summary.pot"),
+                vec![
+                    "src/SUMMARY.md:1",
+                    "src/SUMMARY.md:3",
+                    "src/SUMMARY.md:4",
+                    "src/SUMMARY.md:6",
+                    "src/SUMMARY.md:7",
+                    "src/SUMMARY.md:8",
+                    "src/SUMMARY.md:9",
+                ],
+            ),
+            (
+                path::PathBuf::from("summary/intro.pot"),
+                vec!["src/index.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter.pot"),
+                vec!["src/foo.md:1", "src/foo/bar.md:1", "src/foo/bar/baz.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/foo-exercises.pot"),
+                vec!["src/exercises/foo.md:1"],
+            ),
+        ]);
+
+        assert_eq!(expected_message_tuples.keys().len(), catalogs.len());
+        for (file_path, catalog) in catalogs {
+            let expected_msgids = &expected_message_tuples[&file_path];
+            assert_eq!(
+                &catalog
+                    .messages()
+                    .map(|msg| msg.source())
+                    .collect::<Vec<_>>(),
+                expected_msgids
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_catalog_nested_directories_depth_3() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            (
+                "book.toml",
+                "[book]\n\
+                 [output.xgettext]\n\
+                 depth = 3",
+            ),
+            (
+                "src/SUMMARY.md",
+                "# Summary\n\n\
+                 - [Intro](index.md)\n\
+                 # Foo\n\n\
+                 - [The Foo Chapter](foo.md)\n\
+                 \t- [The Bar Section](foo/bar.md)\n\
+                 \t\t- [The Baz Subsection](foo/bar/baz.md)\n\
+                 - [Foo Exercises](exercises/foo.md)",
+            ),
+            ("src/index.md", "# Intro to X"),
+            ("src/foo.md", "# How to Foo"),
+            ("src/foo/bar.md", "# How to Bar"),
+            ("src/foo/bar/baz.md", "# How to Baz"),
+            ("src/exercises/foo.md", "# Exercises on Foo"),
+        ])?;
+
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+
+        let expected_message_tuples = HashMap::from([
+            (
+                path::PathBuf::from("summary/summary.pot"),
+                vec![
+                    "src/SUMMARY.md:1",
+                    "src/SUMMARY.md:3",
+                    "src/SUMMARY.md:4",
+                    "src/SUMMARY.md:6",
+                    "src/SUMMARY.md:7",
+                    "src/SUMMARY.md:8",
+                    "src/SUMMARY.md:9",
+                ],
+            ),
+            (
+                path::PathBuf::from("summary/intro.pot"),
+                vec!["src/index.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter.pot"),
+                vec!["src/foo.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter/the-bar-section.pot"),
+                vec!["src/foo/bar.md:1", "src/foo/bar/baz.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/foo-exercises.pot"),
+                vec!["src/exercises/foo.md:1"],
+            ),
+        ]);
+
+        assert_eq!(expected_message_tuples.keys().len(), catalogs.len());
+        for (file_path, catalog) in catalogs {
+            let expected_msgids = &expected_message_tuples[&file_path];
+            assert_eq!(
+                &catalog
+                    .messages()
+                    .map(|msg| msg.source())
+                    .collect::<Vec<_>>(),
+                expected_msgids
+            );
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_split_catalog_nested_directories_depth_4() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            (
+                "book.toml",
+                "[book]\n\
+                 [output.xgettext]\n\
+                 depth = 4",
+            ),
+            (
+                "src/SUMMARY.md",
+                "# Summary\n\n\
+                 - [Intro](index.md)\n\
+                 # Foo\n\n\
+                 - [The Foo Chapter](foo.md)\n\
+                 \t- [The Bar Section](foo/bar.md)\n\
+                 \t\t- [The Baz Subsection](foo/bar/baz.md)\n\
+                 - [Foo Exercises](exercises/foo.md)",
+            ),
+            ("src/index.md", "# Intro to X"),
+            ("src/foo.md", "# How to Foo"),
+            ("src/foo/bar.md", "# How to Bar"),
+            ("src/foo/bar/baz.md", "# How to Baz"),
+            ("src/exercises/foo.md", "# Exercises on Foo"),
+        ])?;
+
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+
+        let expected_message_tuples = HashMap::from([
+            (
+                path::PathBuf::from("summary/summary.pot"),
+                vec![
+                    "src/SUMMARY.md:1",
+                    "src/SUMMARY.md:3",
+                    "src/SUMMARY.md:4",
+                    "src/SUMMARY.md:6",
+                    "src/SUMMARY.md:7",
+                    "src/SUMMARY.md:8",
+                    "src/SUMMARY.md:9",
+                ],
+            ),
+            (
+                path::PathBuf::from("summary/intro.pot"),
+                vec!["src/index.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter.pot"),
+                vec!["src/foo.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter/the-bar-section.pot"),
+                vec!["src/foo/bar.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter/the-bar-section/the-baz-subsection.pot"),
+                vec!["src/foo/bar/baz.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/foo-exercises.pot"),
+                vec!["src/exercises/foo.md:1"],
+            ),
+        ]);
+
+        assert_eq!(expected_message_tuples.keys().len(), catalogs.len());
+        for (file_path, catalog) in catalogs {
+            let expected_msgids = &expected_message_tuples[&file_path];
+            assert_eq!(
+                &catalog
+                    .messages()
+                    .map(|msg| msg.source())
+                    .collect::<Vec<_>>(),
+                expected_msgids
+            );
+        }
+
+        Ok(())
+    }
+
+    // The output is expected to be the same as the above test, there
+    // should be no difference if the split depth is an arbitrarily
+    // large number.
+    #[test]
+    fn test_split_catalog_nested_directories_depth_greater_than_necessary() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            (
+                "book.toml",
+                "[book]\n\
+                 [output.xgettext]\n\
+                 depth = 100",
+            ),
+            (
+                "src/SUMMARY.md",
+                "# Summary\n\n\
+                 - [Intro](index.md)\n\
+                 # Foo\n\n\
+                 - [The Foo Chapter](foo.md)\n\
+                 \t- [The Bar Section](foo/bar.md)\n\
+                 \t\t- [The Baz Subsection](foo/bar/baz.md)\n\
+                 - [Foo Exercises](exercises/foo.md)",
+            ),
+            ("src/index.md", "# Intro to X"),
+            ("src/foo.md", "# How to Foo"),
+            ("src/foo/bar.md", "# How to Bar"),
+            ("src/foo/bar/baz.md", "# How to Baz"),
+            ("src/exercises/foo.md", "# Exercises on Foo"),
+        ])?;
+
+        let catalogs = create_catalogs(&ctx, std::fs::read_to_string)?;
+
+        let expected_message_tuples = HashMap::from([
+            (
+                path::PathBuf::from("summary/summary.pot"),
+                vec![
+                    "src/SUMMARY.md:1",
+                    "src/SUMMARY.md:3",
+                    "src/SUMMARY.md:4",
+                    "src/SUMMARY.md:6",
+                    "src/SUMMARY.md:7",
+                    "src/SUMMARY.md:8",
+                    "src/SUMMARY.md:9",
+                ],
+            ),
+            (
+                path::PathBuf::from("summary/intro.pot"),
+                vec!["src/index.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter.pot"),
+                vec!["src/foo.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter/the-bar-section.pot"),
+                vec!["src/foo/bar.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/the-foo-chapter/the-bar-section/the-baz-subsection.pot"),
+                vec!["src/foo/bar/baz.md:1"],
+            ),
+            (
+                path::PathBuf::from("foo/foo-exercises.pot"),
+                vec!["src/exercises/foo.md:1"],
+            ),
+        ]);
+
+        assert_eq!(expected_message_tuples.keys().len(), catalogs.len());
+        for (file_path, catalog) in catalogs {
+            let expected_msgids = &expected_message_tuples[&file_path];
+            assert_eq!(
+                &catalog
+                    .messages()
+                    .map(|msg| msg.source())
+                    .collect::<Vec<_>>(),
+                expected_msgids
+            );
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Hey all! This is a PR in relation to #67 to split the pot file depending on
the specified depth. Another PR will be submitted to change `gettext`
to merge a directory of `pot` files.

- Add an input param to `xgettext` to take in an integer for the depth to
  split the POT file. Remove the input-file param
- Mimics the same structure as the SUMMARY file for the Book
- Revise the helper fn to create a render ctx for tests. Now, it can
  create on-the-fly directories if the markdown file exists in a
sub-directory
- Test the new split catalog function with different possible inputs