### PR TITLE
Set POT-Creation-Date in newly generated POT files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,6 +418,7 @@ name = "mdbook-i18n-helpers"
 version = "0.2.3"
 dependencies = [
  "anyhow",
+ "chrono",
  "mdbook",
  "polib",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ description = "Plugins for a mdbook translation workflow based on Gettext."
 
 [dependencies]
 anyhow = "1.0.68"
+chrono = { version = "0.4.31", default-features = false, features = ["alloc"] }
 mdbook = { version = "0.4.25", default-features = false }
 polib = "0.2.0"
 pulldown-cmark = { version = "0.9.2", default-features = false }

--- a/src/bin/mdbook-xgettext.rs
+++ b/src/bin/mdbook-xgettext.rs
@@ -48,6 +48,8 @@ fn create_catalog(ctx: &RenderContext) -> anyhow::Result<Catalog> {
     if let Some(lang) = &ctx.config.book.language {
         metadata.language = String::from(lang);
     }
+    let now = chrono::Local::now();
+    metadata.pot_creation_date = now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
     metadata.mime_version = String::from("1.0");
     metadata.content_type = String::from("text/plain; charset=UTF-8");
     metadata.content_transfer_encoding = String::from("8bit");
@@ -149,6 +151,8 @@ mod tests {
 
         let catalog = create_catalog(&ctx).unwrap();
         assert_eq!(catalog.metadata.project_id_version, "");
+        assert!(!catalog.metadata.pot_creation_date.is_empty());
+        assert!(catalog.metadata.po_revision_date.is_empty());
         assert_eq!(catalog.metadata.language, "en");
         assert_eq!(catalog.metadata.mime_version, "1.0");
         assert_eq!(catalog.metadata.content_type, "text/plain; charset=UTF-8");


### PR DESCRIPTION
The data is added to PO files automatically by `msgmerge`. This will in turn be used when publishing a translation: it allows us to know which sources goes into a given PO file.

Part of #16.