### PR TITLE
Specify resolver types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
 [workspace]
 members = ["i18n-helpers"]
 default-members = ["i18n-helpers"]
+resolver = "2"


### PR DESCRIPTION
As I was following the testing instructions on https://github.com/google/mdbook-i18n-helpers/discussions/73 

when I stumbled on this: 

<img width="1484" alt="Screen Shot 2023-09-26 at 12 54 50 PM" src="https://github.com/google/mdbook-i18n-helpers/assets/38759997/b6dbd4a9-7140-4535-812b-3caf183023ec">


I fixed this error by specify the resolver version. 