### PR TITLE
Wrap the source lines like `msgmerge` does

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ dependencies = [
  "semver",
  "serde_json",
  "tempfile",
+ "textwrap",
 ]
 
 [[package]]
@@ -732,6 +733,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -19,6 +19,7 @@ pulldown-cmark-to-cmark = "11.0.0"
 regex = "1.9.4"
 semver = "1.0.16"
 serde_json = "1.0.91"
+textwrap = { version = "0.16.0", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/i18n-helpers/src/bin/mdbook-xgettext.rs
+++ b/i18n-helpers/src/bin/mdbook-xgettext.rs
@@ -29,8 +29,11 @@ use polib::metadata::CatalogMetadata;
 use std::{fs, io};
 
 fn add_message(catalog: &mut Catalog, msgid: &str, source: &str) {
+    let wrap_options = textwrap::Options::new(76)
+        .break_words(false)
+        .word_splitter(textwrap::WordSplitter::NoHyphenation);
     let sources = match catalog.find_message(None, msgid, None) {
-        Some(msg) => format!("{}\n{}", msg.source(), source),
+        Some(msg) => textwrap::refill(&format!("{}\n{}", msg.source(), source), wrap_options),
         None => String::from(source),
     };
     let message = Message::build_singular()


### PR DESCRIPTION
This will reduce churn between the output of `mdbook-xgettext` and `msgmerge`. See https://github.com/google/comprehensive-rust/pull/1245 for an example PR which would shrink with this feature.

Part of #32, but we still have differences in the way the messages themselves are wrapped.