### PR TITLE
Fix caching of `target` dir for `fuzz` project

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/checkout@v3
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test
         run: cargo test
@@ -35,18 +37,17 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          workspaces: fuzz -> target
+          # Default is "v0-rust"
+          # Use a separate key to prevent collision with main cache
+          prefix-key: "fuzz"
+          # Cache only on main build
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          cache-directories: |
+            i18n-helpers/fuzz/target
+            i18n-helpers/fuzz/corpus
 
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
-
-      - name: Cache fuzz corpus
-        uses: actions/cache@v3
-        with:
-          path: fuzz/corpus
-          key: fuzz-corpus-${{ github.run_id }}
-          restore-keys: |
-            fuzz-corpus
 
       - name: Run group_events fuzzer and minimize corpus
         run: |

--- a/i18n-helpers/fuzz/Cargo.lock
+++ b/i18n-helpers/fuzz/Cargo.lock
@@ -453,6 +453,7 @@ dependencies = [
  "regex",
  "semver",
  "serde_json",
+ "textwrap",
 ]
 
 [[package]]
@@ -767,6 +768,12 @@ dependencies = [
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"


### PR DESCRIPTION
Currently caching does not work for `fuzz` job which can be verified by looking at Github workflow outputs.

The main cause of the issue is the config `workspaces: fuzz -> target`. The fuzz target does not use a proper workspace but a separate crate. There is [a pending issue](https://github.com/rust-fuzz/cargo-fuzz/issues/345) discussing that.

The `rust-cache` action is executed in the root of the project and is not able to locate `fuzz` directory by workspace name.

I decided to list the directories to cache instead of relying on target dir detection which seems to work.

I also fixed the path `fuzz/corpus` to `i18n-helpers/fuzz/corpus`.

I adjusted the caching condition `save-if` to cache only on `main` builds. I think this makes sense because we don't need to cache PRs which might not get merged or get updated multiple times during review.