### PR TITLE
Add translator comment parsing

### DIFF
--- a/i18n-helpers/src/directives.rs
+++ b/i18n-helpers/src/directives.rs
@@ -1,0 +1,104 @@
+use regex::Regex;
+use std::sync::OnceLock;
+
+#[derive(Debug, PartialEq)]
+pub enum Directive {
+    Skip,
+    TranslatorComment(String),
+}
+
+pub fn find(html: &str) -> Option<Directive> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        let pattern = r"(?x)
+              <!-{2,}\s*                  # the opening of the comment
+              (?:i18n|mdbook-xgettext)    # the prefix
+              \s*:                        # delimit between prefix and command
+              (?<command>.*[^-])          # the command part of the prefix
+              -{2,}>                      # the closing of the comment
+        ";
+        Regex::new(pattern).expect("well-formed regex")
+    });
+
+    let captures = re.captures(html.trim())?;
+
+    let command = captures["command"].trim();
+    match command.split(is_delimiter).next() {
+        Some("skip") => Some(Directive::Skip),
+        Some("comment") => {
+            let start_of_comment_offset = std::cmp::min(
+                command.find("comment").unwrap() + "comment".len() + 1,
+                command.len(),
+            );
+            Some(Directive::TranslatorComment(
+                command[start_of_comment_offset..].trim().into(),
+            ))
+        }
+        _ => None,
+    }
+}
+
+fn is_delimiter(c: char) -> bool {
+    c.is_whitespace() || c == ':' || c == '-'
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_comment_skip_directive_simple() {
+        assert!(matches!(find("<!-- i18n:skip -->"), Some(Directive::Skip)));
+    }
+
+    #[test]
+    fn test_is_comment_skip_directive_tolerates_spaces() {
+        assert!(matches!(find("<!-- i18n: skip -->"), Some(Directive::Skip)));
+    }
+
+    #[test]
+    fn test_is_comment_skip_directive_tolerates_dashes() {
+        assert!(matches!(
+            find("<!--- i18n:skip ---->"),
+            Some(Directive::Skip)
+        ));
+    }
+
+    #[test]
+    fn test_is_comment_skip_directive_needs_skip() {
+        assert!(find("<!-- i18n: foo -->").is_none());
+    }
+
+    #[test]
+    fn test_is_comment_skip_directive_needs_to_be_a_comment() {
+        assert!(find("<div>i18: skip</div>").is_none());
+    }
+
+    #[test]
+    fn test_different_prefix() {
+        assert!(matches!(
+            find("<!-- mdbook-xgettext:skip -->"),
+            Some(Directive::Skip)
+        ));
+    }
+
+    #[test]
+    fn test_translator_comment() {
+        assert!(match find("<!-- i18n:comment: hello world! -->") {
+            Some(Directive::TranslatorComment(s)) => {
+                s == "hello world!"
+            }
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_translator_empty_comment_does_nothing() {
+        assert!(match find("<!-- i18n:comment -->") {
+            Some(Directive::TranslatorComment(s)) => {
+                s.is_empty()
+            }
+            _ => false,
+        });
+    }
+}

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -26,11 +26,11 @@
 use polib::catalog::Catalog;
 use pulldown_cmark::{CodeBlockKind, Event, LinkType, Tag};
 use pulldown_cmark_to_cmark::{cmark_resume_with_options, Options, State};
-use regex::Regex;
 use std::sync::OnceLock;
 use syntect::easy::ScopeRangeIterator;
 use syntect::parsing::{ParseState, Scope, ScopeStack, SyntaxSet};
 
+pub mod directives;
 pub mod gettext;
 pub mod normalize;
 
@@ -287,22 +287,34 @@ pub fn group_events<'a>(events: &'a [(usize, Event<'a>)]) -> Vec<Group<'a>> {
                 }
             }
 
-            // An HTML comment directive to skip the next translation
-            // group.
-            Event::Html(s) if is_comment_skip_directive(s) => {
-                // If in the middle of translation, finish it.
-                if let State::Translate(_) = state {
-                    let mut next_groups;
-                    (next_groups, ctx) = state.into_groups(idx, events, ctx);
-                    groups.append(&mut next_groups);
+            Event::Html(s) => {
+                match directives::find(s) {
+                    Some(directives::Directive::Skip) => {
+                        // If in the middle of translation, finish it.
+                        if let State::Translate(_) = state {
+                            let mut next_groups;
+                            (next_groups, ctx) = state.into_groups(idx, events, ctx);
+                            groups.append(&mut next_groups);
 
-                    // Restart translation: subtle but should be
-                    // needed to handle the skipping of the rest of
-                    // the inlined content.
-                    state = State::Translate(idx);
+                            // Restart translation: subtle but should be
+                            // needed to handle the skipping of the rest of
+                            // the inlined content.
+                            state = State::Translate(idx);
+                        }
+
+                        ctx.skip_next_group = true;
+                    }
+                    // Otherwise, treat as a skipping group.
+                    _ => {
+                        if let State::Translate(_) = state {
+                            let mut next_groups;
+                            (next_groups, ctx) = state.into_groups(idx, events, ctx);
+                            groups.append(&mut next_groups);
+
+                            state = State::Skip(idx);
+                        }
+                    }
                 }
-
-                ctx.skip_next_group = true;
             }
 
             // All other block-level events start or continue a
@@ -325,15 +337,6 @@ pub fn group_events<'a>(events: &'a [(usize, Event<'a>)]) -> Vec<Group<'a>> {
     }
 
     groups
-}
-
-/// Check whether the HTML is a directive to skip the next translation group.
-fn is_comment_skip_directive(html: &str) -> bool {
-    static RE: OnceLock<Regex> = OnceLock::new();
-
-    let re =
-        RE.get_or_init(|| Regex::new(r"<!-{2,}\s*mdbook-xgettext\s*:\s*skip\s*-{2,}>").unwrap());
-    re.is_match(html.trim())
 }
 
 /// Returns true if the events appear to be a codeblock.
@@ -1294,45 +1297,7 @@ $$
     }
 
     #[test]
-    fn test_is_comment_skip_directive_simple() {
-        assert_eq!(
-            is_comment_skip_directive("<!-- mdbook-xgettext:skip -->"),
-            true
-        );
-    }
 
-    #[test]
-    fn test_is_comment_skip_directive_tolerates_spaces() {
-        assert_eq!(
-            is_comment_skip_directive("<!-- mdbook-xgettext: skip -->"),
-            true
-        );
-    }
-
-    #[test]
-    fn test_is_comment_skip_directive_tolerates_dashes() {
-        assert_eq!(
-            is_comment_skip_directive("<!--- mdbook-xgettext:skip ---->"),
-            true
-        );
-    }
-
-    #[test]
-    fn test_is_comment_skip_directive_needs_skip() {
-        assert_eq!(
-            is_comment_skip_directive("<!-- mdbook-xgettext: foo -->"),
-            false
-        );
-    }
-    #[test]
-    fn test_is_comment_skip_directive_needs_to_be_a_comment() {
-        assert_eq!(
-            is_comment_skip_directive("<div>mdbook-xgettext: skip</div>"),
-            false
-        );
-    }
-
-    #[test]
     fn extract_messages_skip_simple() {
         assert_extract_messages(
             r#"<!-- mdbook-xgettext:skip -->


### PR DESCRIPTION
This moves the comment directive parsing to a separate module and adds two features:

* Customizable prefix for the directive.   It defaults to "i18", but to maintain compatibility, overridden with "mdbook-xgettext"  in its current usage.
* Can parse translator comments.

This is preparatory work to thread this state during message extraction.