### PR TITLE
Test `extract_messages` with backslashes

### DIFF
--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -1059,6 +1059,24 @@ The document[^1] text.
     }
 
     #[test]
+    fn extract_messages_backslashes() {
+        // Demonstrate how a single backslash in the Markdown becomes
+        // a backslash-escaped backslash when we extract the text.
+        // This is consistent with the CommonMark spec:
+        // https://spec.commonmark.org/0.30/#backslash-escapes.
+        // However, it causes problems for LaTeX preprocessors:
+        // https://github.com/google/mdbook-i18n-helpers/issues/105.
+        assert_extract_messages(
+            r#"
+$$
+\sum_{n=1}^{\infty} 2^{-n} = 1
+$$
+"#,
+            vec![(2, r#"$$ \\sum\_{n=1}^{\infty} 2^{-n} = 1 $$"#)],
+        )
+    }
+
+    #[test]
     fn test_is_comment_skip_directive_simple() {
         assert_eq!(
             is_comment_skip_directive("<!-- mdbook-xgettext:skip -->"),


### PR DESCRIPTION
This is part of #105, the test demonstrates how we extract backslashes: `\` (a single backslash) in the Markdown file becomes `\\` (a backslash-escaped backslash) afterwards.

This is consistent with the Commonmark spec, which says that a backslash-escaped backslash is how you can represent a backslash in the document: https://spec.commonmark.org/0.30/#backslash-escapes.

However, it can lead to problems if the LaTeX preprocessor doesn’t handle `\\` in the Markdown file as a `\`.