### PR TITLE
Deny all default Clippy errors/warnings in github workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy
-        run: cargo clippy -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr
+        run: cargo clippy -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
+
+      - name: Clippy on fuzzers
+        working-directory: ./i18n-helpers/fuzz
+        run: cargo clippy -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
 
   format:
     name: Format


### PR DESCRIPTION
When addressing [this comment](https://github.com/google/mdbook-i18n-helpers/pull/104#discussion_r1375514472)

> `You should at least trip the return which is not necessary here.`

I noticed Clippy warnings such as `warning: unneeded "return" statement` and others like [this](https://github.com/google/mdbook-i18n-helpers/actions/runs/6686046766/job/18164991850?pr=104) do not produce  non-zero status code which means the PR won't fail.

I am adding `-D clippy::all` in order to deny all default warnings to fail PRs.

Also adding a separate call to `cargo clippy` in directory `i18n-helpers/fuzz` because it is considered to be a separate workspace.