### PR TITLE
Skip extracting whitespace-only messages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,39 @@ jobs:
       - name: Test
         run: cargo test
 
+  rust-book:
+    name: Test with Rust Book
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install tools
+        run: |
+          sudo apt install gettext
+          # Debug builds are fine and slightly faster.
+          cargo install --debug --path i18n-helpers
+          cargo install --debug --locked --version 0.4.35 mdbook
+
+      - name: Checkout Rust Book
+        uses: actions/checkout@v4
+        with:
+          repository: rust-lang/book
+          # Update the commit hash once in a while to test newer
+          # versions.
+          ref: 5b6c1ceaa62ecbd6caef08df39b33b3938e99deb
+          path: rust-book
+
+      - name: Test extracting text from Rust Book
+        working-directory: rust-book
+        run: |
+          MDBOOK_OUTPUT='{"xgettext": {"pot-file": "messages.pot"}}' mdbook build -d po
+          msgfmt -o /dev/null --statistics po/messages.pot
+
   fuzz:
     name: Fuzz test
     runs-on: ubuntu-latest

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -463,7 +463,11 @@ pub fn extract_messages(document: &str) -> Vec<(usize, String)> {
             Group::Translate(events) => {
                 if let Some((lineno, _)) = events.first() {
                     let (text, new_state) = reconstruct_markdown(events, state);
-                    messages.push((*lineno, text));
+                    // Skip empty messages since they are special:
+                    // they contains the PO file metadata.
+                    if !text.trim().is_empty() {
+                        messages.push((*lineno, text));
+                    }
                     state = Some(new_state);
                 }
             }
@@ -687,6 +691,16 @@ mod tests {
     #[test]
     fn extract_messages_empty() {
         assert_extract_messages("", vec![]);
+    }
+
+    #[test]
+    fn extract_messages_empty_html() {
+        assert_extract_messages("<span></span>", vec![]);
+    }
+
+    #[test]
+    fn extract_messages_whitespace_only() {
+        assert_extract_messages("<span>  </span>", vec![]);
     }
 
     #[test]


### PR DESCRIPTION
This skips empty messages and messages consisting of whitespace only.

Fixes #64.