### PR TITLE
Drop unnecessary hashes from raw strings.

### DIFF
--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -1125,7 +1125,7 @@ The document[^1] text.
     #[test]
     fn extract_messages_multi_language_code_blocks() {
         assert_extract_messages(
-            r##"```c
+            r#"```c
 // C
 'C'; "C";
 ```
@@ -1138,7 +1138,7 @@ HTML -->
 ```
 ```ruby
 # Ruby
-```"##,
+```"#,
             vec![
                 (2, "// C\n'C'"),
                 (3, "\"C\""),
@@ -1284,12 +1284,12 @@ HTML -->
         // However, it causes problems for LaTeX preprocessors:
         // https://github.com/google/mdbook-i18n-helpers/issues/105.
         assert_extract_messages(
-            r#"
+            r"
 $$
 \sum_{n=1}^{\infty} 2^{-n} = 1
 $$
-"#,
-            vec![(2, r#"$$ \\sum\_{n=1}^{\infty} 2^{-n} = 1 $$"#)],
+",
+            vec![(2, r"$$ \\sum\_{n=1}^{\infty} 2^{-n} = 1 $$")],
         )
     }
 


### PR DESCRIPTION
We drop some unnecessary escapes from the raw strings.  This is to clean up some lint warnings from Clippy.