### PR TITLE
Wrap source lines in `mdbook-i18n-normalize`

### DIFF
--- a/i18n-helpers/src/bin/mdbook-xgettext.rs
+++ b/i18n-helpers/src/bin/mdbook-xgettext.rs
@@ -22,7 +22,7 @@
 use anyhow::{anyhow, Context};
 use mdbook::renderer::RenderContext;
 use mdbook::BookItem;
-use mdbook_i18n_helpers::{extract_events, extract_messages, reconstruct_markdown};
+use mdbook_i18n_helpers::{extract_events, extract_messages, reconstruct_markdown, wrap_sources};
 use polib::catalog::Catalog;
 use polib::message::Message;
 use polib::metadata::CatalogMetadata;
@@ -44,11 +44,8 @@ fn strip_link(text: &str) -> String {
 }
 
 fn add_message(catalog: &mut Catalog, msgid: &str, source: &str) {
-    let wrap_options = textwrap::Options::new(76)
-        .break_words(false)
-        .word_splitter(textwrap::WordSplitter::NoHyphenation);
     let sources = match catalog.find_message(None, msgid, None) {
-        Some(msg) => textwrap::refill(&format!("{}\n{}", msg.source(), source), wrap_options),
+        Some(msg) => wrap_sources(&format!("{}\n{}", msg.source(), source)),
         None => String::from(source),
     };
     let message = Message::build_singular()

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -34,6 +34,17 @@ use syntect::parsing::{ParseState, Scope, ScopeStack, SyntaxSet};
 pub mod gettext;
 pub mod normalize;
 
+/// Re-wrap the sources field of a message.
+///
+/// This function tries to wrap the `file:lineno` pairs so they look
+/// the same as what you get from `msgcat` or `msgmerge`.
+pub fn wrap_sources(sources: &str) -> String {
+    let options = textwrap::Options::new(76)
+        .break_words(false)
+        .word_splitter(textwrap::WordSplitter::NoHyphenation);
+    textwrap::refill(sources, options)
+}
+
 /// Like `mdbook::utils::new_cmark_parser`, but also passes a
 /// `BrokenLinkCallback`.
 pub fn new_cmark_parser<'input, 'callback>(

--- a/i18n-helpers/src/normalize.rs
+++ b/i18n-helpers/src/normalize.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::Read;
 
-use super::{extract_messages, new_cmark_parser};
+use crate::{extract_messages, new_cmark_parser, wrap_sources};
 use polib::catalog::Catalog;
 use polib::message::{Message, MessageFlags, MessageMutView, MessageView};
 use pulldown_cmark::{Event, LinkType, Tag};
@@ -30,7 +30,7 @@ fn compute_source(source: &str, delta: usize) -> String {
         }
     }
 
-    new_source
+    wrap_sources(&new_source)
 }
 
 /// Check if `text` contains one or more broken reference links.


### PR DESCRIPTION
Noticed by @henrif75 in https://github.com/google/comprehensive-rust/issues/317.

Part of #32 and a followup to #93.