### PR TITLE
Ensure we run tests and Clipply on entire workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
   FORCE_COLOR: 3
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,11 +132,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy
-        run: cargo clippy -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
+        run: cargo clippy --all-targets -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
 
       - name: Clippy on fuzzers
         working-directory: ./i18n-helpers/fuzz
-        run: cargo clippy -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
+        run: cargo clippy --all-targets -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
 
   format:
     name: Format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,11 +133,11 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Clippy
-        run: cargo clippy --all-targets -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
+        run: cargo clippy --all-targets
 
       - name: Clippy on fuzzers
         working-directory: ./i18n-helpers/fuzz
-        run: cargo clippy --all-targets -- -D clippy::dbg_macro -D clippy::print_stdout -D clippy::print_stderr -D clippy::all
+        run: cargo clippy --all-targets
 
   format:
     name: Format

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,20 +100,20 @@ jobs:
         run: cargo install cargo-fuzz
 
       - name: Run group_events fuzzer and minimize corpus
+        working-directory: i18n-helpers
         run: |
-          cd i18n-helpers
           cargo fuzz run group_events -- -only_ascii=1 -max_total_time=30
           cargo fuzz cmin group_events
 
       - name: Run normalize fuzzer and minimize corpus
+        working-directory: i18n-helpers
         run: |
-          cd i18n-helpers
           cargo fuzz run normalize -- -only_ascii=1 -max_total_time=30
           cargo fuzz cmin normalize
 
       - name: Run gettext fuzzer and minimize corpus
+        working-directory: i18n-helpers
         run: |
-          cd i18n-helpers
           cargo fuzz run gettext -- -only_ascii=1 -max_total_time=30
           cargo fuzz cmin gettext
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,11 @@ members = ["i18n-helpers", "mdbook-tera-backend"]
 default-members = ["i18n-helpers", "mdbook-tera-backend"]
 resolver = "2"
 
+[workspace.lints.clippy]
+dbg_macro = "warn"
+print_stdout = "warn"
+print_stderr = "warn"
+
 [workspace.dependencies]
 anyhow = "1.0.79"
 mdbook = { version = "0.4.36", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["i18n-helpers", "mdbook-tera-backend"]
-default-members = ["i18n-helpers"]
+default-members = ["i18n-helpers", "mdbook-tera-backend"]
 resolver = "2"
 
 [workspace.dependencies]

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 repository = "https://github.com/google/mdbook-i18n-helpers"
 description = "Plugins for a mdbook translation workflow based on Gettext."
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 chrono = { version = "0.4.31", default-features = false, features = ["alloc"] }

--- a/i18n-helpers/fuzz/Cargo.toml
+++ b/i18n-helpers/fuzz/Cargo.toml
@@ -7,6 +7,11 @@ publish = false
 [package.metadata]
 cargo-fuzz = true
 
+[lints.clippy]
+dbg_macro = "warn"
+print_stdout = "warn"
+print_stderr = "warn"
+
 [dependencies]
 arbitrary = { version = "1.3.1", features = ["derive"] }
 libfuzzer-sys = "0.4.0"

--- a/mdbook-tera-backend/Cargo.toml
+++ b/mdbook-tera-backend/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 repository = "https://github.com/google/mdbook-i18n-helpers"
 description = "Plugin to extend mdbook with Tera templates and custom HTML components."
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 mdbook.workspace = true


### PR DESCRIPTION
Before, we did not actually run tests for `mdbook-tera-backend`. Now that the crate is a default workspace member, we will automatically run tests and Clippy for it too.

This also makes it easier to apply the same lints at home as in CI: just run `cargo clippy` with a nightly Rust compiler. The `lints` table should [become stable with Rust 1.74](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#lints).
