### PR TITLE
Fix codeblock in codeblock

### DIFF
--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -557,7 +557,11 @@ pub fn reconstruct_markdown(
     (String::from(markdown.trim_start_matches('\n')), new_state)
 }
 
-/// Check appropriate codeblock token count
+/// Check appropriate codeblock token count.
+///
+/// This is necessary to handle codeblocks inside codeblocks.
+/// See https://github.com/Byron/pulldown-cmark-to-cmark/issues/20
+/// for a related upstream issue.
 fn check_code_block_token_count(group: &[(usize, Event)]) -> usize {
     let events = group.iter().map(|(_, event)| event);
     let mut in_codeblock = false;


### PR DESCRIPTION
Codeblock which contains ```` ``` ```` will be like below:

`````markdown
````markdown
```rust
let a = 0;
```
````
`````

But the output of mdbook-i18n-helpers seems to be broken like below:

`````markdown
```markdown
```rust
let a = 0;
```
```
`````

This is because codeblock token count is fixed as 3 in `reconstruct_markdown`.
This PR adds to check the appropriate codeblock token count.