### PR TITLE
Share common workspace dependencies in root Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,9 @@
 members = ["i18n-helpers", "mdbook-tera-backend"]
 default-members = ["i18n-helpers"]
 resolver = "2"
+
+[workspace.dependencies]
+anyhow = "1.0.79"
+mdbook = { version = "0.4.36", default-features = false }
+serde_json = "1.0.111"
+tempfile = "3.9.0"

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -10,18 +10,18 @@ repository = "https://github.com/google/mdbook-i18n-helpers"
 description = "Plugins for a mdbook translation workflow based on Gettext."
 
 [dependencies]
-anyhow = "1.0.79"
+anyhow.workspace = true
 chrono = { version = "0.4.31", default-features = false, features = ["alloc"] }
-mdbook = { version = "0.4.36", default-features = false }
+mdbook.workspace = true
 polib = "0.2.0"
 pulldown-cmark = { version = "0.9.2", default-features = false }
 pulldown-cmark-to-cmark = "11.0.2"
 regex = "1.9.4"
 semver = "1.0.21"
-serde_json = "1.0.111"
+serde_json.workspace = true
 syntect = "5.1.0"
 textwrap = { version = "0.16.0", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
-tempfile = "3.9.0"
+tempfile.workspace = true

--- a/mdbook-tera-backend/Cargo.toml
+++ b/mdbook-tera-backend/Cargo.toml
@@ -10,11 +10,11 @@ repository = "https://github.com/google/mdbook-i18n-helpers"
 description = "Plugin to extend mdbook with Tera templates and custom HTML components."
 
 [dependencies]
-anyhow = "1.0.79"
-mdbook = { version = "0.4.36", default-features = false }
+anyhow.workspace = true
+mdbook.workspace = true
 serde = "1.0"
-serde_json = "1.0.111"
+serde_json.workspace = true
 tera = "1.19.1"
 
 [dev-dependencies]
-tempfile = "3.9.0"
+tempfile.workspace = true


### PR DESCRIPTION
This approach makes dependency version management between workspace members cleaner as documented in
https://doc.rust-lang.org/nightly/cargo/reference/workspaces.html#the-dependencies-table