### PR TITLE
Implement coverage reports using codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,8 +22,17 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Test
-        run: cargo test
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
+      - name: Run tests with Coverage report enabled
+        run: cargo llvm-cov test --all-features --workspace --codecov --output-path codecov-report.json
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: codecov-report.json
+          fail_ci_if_error: true
 
   test-other-books:
     strategy:


### PR DESCRIPTION
[cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) is used for generating coverage reports.

The library supports different report types which all have their own pros and cons:

* `--lcov` - reports in `lcov` format which are supported by Codecov. They support only line level coverage and will not provide any info on regions. Example report can be seen [here](https://app.codecov.io/gh/kdarkhan/mdbook-i18n-helpers/commit/f8e7bb95e74031e9a2276defda8b99ece4046cc8/tree).
* `--codecov` - Codecov's custom format which somewhat supports region coverage but not fully. Example report can be seen [here](https://app.codecov.io/gh/kdarkhan/mdbook-i18n-helpers/commit/b3384aa77c7ea7172324a292fcc12568ed5511fc/tree). Notice that some lines are colored in yellow - which means they are partially covered but exact regions within lines are not highlighted.
* `--html` - html output which is provided by `llvm-cov`. This output is the most informative as it highlights covered and uncovered regions. I pushed an example of this to Github Pages [here](https://kdarkhan.github.io/mdbook-i18n-helpers/). Unfortunately, Codecov does not support such outputs. We have an option to push these reports manually to some Github Pages repo during PR review. Or we can host these assets in Github Artifacts (GA). GA, however, will not make it easy to preview generated HTML - users will have to download the assets and open locally. More convenient preview in GA is blocked by [this issue](https://github.com/actions/upload-artifact/issues/14). 

Given the above limitations, I propose using `--codecov` based approach which this PR implements.

I am not integrating reports provided by `cargo fuzz coverage` into this yet and planning to do it in a separate PR once we agree on the initial approach. `cargo fuzz coverage` generates an output which is closer to `--lcov` mentioned above. There is a hack that I think can be implemented to make it work with `--codecov` reports.