### PR TITLE
Use project specific codecov token for coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: codecov-report.json
           fail_ci_if_error: true
 


### PR DESCRIPTION
This is an attempt at fixing 503 errors which occur sometimes during coverage uploads
https://github.com/google/mdbook-i18n-helpers/issues/148.