### PR TITLE
Check for duplicate sources in messages

### DIFF
--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -404,4 +404,39 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_create_catalog_lineno_granularity_duplicates() -> anyhow::Result<()> {
+        let (ctx, _tmp) = create_render_context(&[
+            (
+                "book.toml",
+                "[book]\n\
+                 [output.xgettext]\n\
+                 granularity = 3",
+            ),
+            ("src/SUMMARY.md", "- [Foo](foo.md)"),
+            (
+                "src/foo.md",
+                "Bar\n\
+                 \n\
+                 Bar\n\
+                 \n\
+                 Bar\n",
+            ),
+        ])?;
+
+        let catalog = create_catalog(&ctx, std::fs::read_to_string)?;
+        assert_eq!(
+            catalog
+                .messages()
+                .map(|msg| (msg.source(), msg.msgid()))
+                .collect::<Vec<_>>(),
+            &[
+                ("src/SUMMARY.md:1", "Foo"),
+                ("src/foo.md:1 src/foo.md:3", "Bar"),
+            ]
+        );
+
+        Ok(())
+    }
 }

--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -41,7 +41,13 @@ fn strip_link(text: &str) -> String {
 
 fn add_message(catalog: &mut Catalog, msgid: &str, source: &str) {
     let sources = match catalog.find_message(None, msgid, None) {
-        Some(msg) => wrap_sources(&format!("{}\n{}", msg.source(), source)),
+        Some(msg) => {
+            if msg.source().contains(source) {
+                return;
+            }
+
+            wrap_sources(&format!("{}\n{}", msg.source(), source))
+        }
         None => String::from(source),
     };
     let message = Message::build_singular()


### PR DESCRIPTION
With rounded line numbers, it's possible for messages to have duplicate sources. This checks for duplicate sources before updating messages. An alternative approach is deduplicating sources after all the messages are added/updated. I went with the "on-the-fly" approach since it's simpler.

The check scans all of the sources for a message. If performance is a concern, we could try other ways to check for duplicates.

Fixes #154