### PR TITLE
Remove check_code_block_token_count function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -876,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "11.0.2"
+version = "11.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a883e495f8fc4f209521b03a89dde6f6f211ed7cf92e85693c82508e8b722710"
+checksum = "6dd464f32d7631035e849fcd969a603e9bb17ceaebe8467352a7728147f34e42"
 dependencies = [
  "pulldown-cmark",
 ]

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { version = "0.4.31", default-features = false, features = ["alloc"] }
 mdbook.workspace = true
 polib = "0.2.0"
 pulldown-cmark = { version = "0.9.2", default-features = false }
-pulldown-cmark-to-cmark = "11.0.2"
+pulldown-cmark-to-cmark = "11.2.0"
 regex = "1.10.3"
 semver = "1.0.21"
 serde_json.workspace = true


### PR DESCRIPTION
The logic of `check_code_block_token_count` was merged into pulldown-cmark-to-cmark crate.