### PR TITLE
Make codecov report use secret

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -1,0 +1,60 @@
+name: Coverage report
+
+on:
+  # This workflow is triggered after every successfull execution
+  # of `tests` workflow.
+  workflow_run:
+    workflows: ["tests"]
+    types:
+      - completed
+jobs:
+  coverage:
+    name: Coverage report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+
+      - name: 'Download existing coverage report'
+        id: prepare_report
+        uses: actions/github-script@v6
+        with:
+          script: |
+            var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+
+            let matchedArtifact = artifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "codecov-report";
+            });
+
+            if (matchedArtifact && matchedArtifact[0]) {
+
+              var download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchedArtifact[0].id,
+                 archive_format: 'zip',
+              });
+              var fs = require('fs');
+              fs.writeFileSync('${{github.workspace}}/codecov-report.zip', Buffer.from(download.data));
+            } else {
+              console.error('No artifact found');
+            }
+
+      - run: unzip codecov-report.zip
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov-report.json
+          fail_ci_if_error: true
+          # Manual overrides for these parameters are needed because automatic detection
+          # in codecov-action does not work for non-`pull_request` workflows.
+          override_commit: ${{ github.event.workflow_run.pull_requests[0].head.sha }}
+          override_pr: ${{ github.event.workflow_run.pull_requests[0].number }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,12 +29,18 @@ jobs:
       - name: Run tests with Coverage report enabled
         run: cargo llvm-cov test --all-features --workspace --codecov --output-path codecov-report.json
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      # This stores the coverage report in artifacts. The actual upload to Codecov
+      # is executed by a different workflow `coverage-report.yml`. The reason for this
+      # split is because `on.pull_request` workflows don't have access to secrets.
+      - name: Store coverage report in artifacts
+        uses: actions/upload-artifact@v3
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: codecov-report.json
-          fail_ci_if_error: true
+          name: codecov-report
+          path: codecov-report.json
+
+      - run: |
+          echo "The coverage report was stored in Github artifacts."
+          echo "It will be uploaded to Codecov using [coverage-report.yml] workflow shortly."
 
   test-other-books:
     strategy:


### PR DESCRIPTION
This addresses #148. Codecov coverage report upload are not stable. The suggested solution is to use
per project secret. This project have that enabled but it is not usable for pull request workflows triggered from forks. Due to Github's security restrictions, only PRs based on local branches have access to secrets.

This PR amends the existing workflow by not pushing the reports to Codecov. The reports are instead uploaded to Github artifacts (the artifacts are stored for 90 days by default).

Then a new workflow is introduced which executes after every successful execution of the existing workflow. It downloads the artifact and uploads the report to Codecov using the security token.