### PR TITLE
Make dependabot grouping work on all update types

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,12 +7,18 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    groups:
+      minor:
+        update-types:
+          - minor
+      patch:
+        update-types:
+          - patch
 
   - package-ecosystem: cargo
     directory: /
     schedule:
       interval: weekly
-
     groups:
       minor:
         update-types:


### PR DESCRIPTION
The initial version defined groups only for cargo
deps. Because of that, we have 2 separate PRs related to `github-actions`. This ensures that grouping logic works for all deps.