### PR TITLE
Log github.context to investigate missing coverage reports

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            console.log('context.payload is');
+            console.log(JSON.stringify(context.payload, null, 2));
             var artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                owner: context.repo.owner,
                repo: context.repo.repo,


### PR DESCRIPTION
I want to temporarily start logging `github.context` object. It seems the coverage reports sometimes do not get correct [overrides](https://github.com/google/mdbook-i18n-helpers/blob/33fec9577e55e337aee77604da0954285fc56449/.github/workflows/coverage-report.yml#L59-L60).

Because of that, Codecov reports appear as attached to `main` instead of the correct PR.
I tried to reproduce this issue by creating PRs against my fork but did not have any luck.

Interestingly, it does seem to work for some PRs but broken for others.

As I understand, `context.payload` JSON object will have the same content as `github.event` expression in YAML.