### PR TITLE
Revert cocecov-action upgrade

### DIFF
--- a/.github/workflows/coverage-report.yml
+++ b/.github/workflows/coverage-report.yml
@@ -95,7 +95,7 @@ jobs:
           path: repo_root
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ${{ github.workspace }}/codecov_report.json


### PR DESCRIPTION
This is causing coverage reports fail. Reverting this now until we have a working solution

d76153d 'Bump codecov/codecov-action from 3 to 4 (#169)'

Relevant links:
* https://github.com/google/mdbook-i18n-helpers/issues/173
* https://github.com/codecov/feedback/issues/263