### PR TITLE
Upgrade pulldown-cmark to 0.10.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "opener",
- "pulldown-cmark 0.10.3",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde_json",
@@ -645,7 +645,7 @@ dependencies = [
  "mdbook",
  "polib",
  "pretty_assertions",
- "pulldown-cmark 0.9.6",
+ "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "semver",
@@ -911,17 +911,6 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57206b407293d2bcd3af849ce869d52068623f19e1b5ff8e8778e3309439682b"
-dependencies = [
- "bitflags 2.4.1",
- "memchr",
- "unicase",
-]
-
-[[package]]
-name = "pulldown-cmark"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
@@ -940,11 +929,11 @@ checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "11.2.0"
+version = "13.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd464f32d7631035e849fcd969a603e9bb17ceaebe8467352a7728147f34e42"
+checksum = "f609795c8d835f79dcfcf768415b9fb57ef1b74891e99f86e73f43a7a257163b"
 dependencies = [
- "pulldown-cmark 0.9.6",
+ "pulldown-cmark",
 ]
 
 [[package]]

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -17,8 +17,8 @@ anyhow.workspace = true
 chrono = { version = "0.4.38", default-features = false, features = ["alloc"] }
 mdbook.workspace = true
 polib.workspace = true
-pulldown-cmark = { version = "0.9.2", default-features = false }
-pulldown-cmark-to-cmark = "11.2.0"
+pulldown-cmark = { version = "0.10.3", default-features = false, features = ["html"] }
+pulldown-cmark-to-cmark = "13.0.0"
 regex = "1.10.4"
 semver = "1.0.22"
 serde_json.workspace = true

--- a/i18n-helpers/src/gettext.rs
+++ b/i18n-helpers/src/gettext.rs
@@ -310,7 +310,7 @@ mod tests {
         let catalog = create_catalog(&[("Foo", "FOO"), ("Bar", "BAR")]);
         assert_eq!(
             translate("# Foo { #id .foo }", &catalog),
-            "# FOO {#id .foo}"
+            "# FOO { #id .foo }"
         );
     }
 

--- a/i18n-helpers/src/normalize.rs
+++ b/i18n-helpers/src/normalize.rs
@@ -49,11 +49,12 @@ fn has_broken_link(text: &str) -> bool {
     new_cmark_parser(text, Some(&mut callback)).any(|event| {
         matches!(
             event,
-            Event::Start(Tag::Link(
-                LinkType::ReferenceUnknown | LinkType::CollapsedUnknown | LinkType::ShortcutUnknown,
-                _,
-                _
-            ))
+            Event::Start(Tag::Link {
+                link_type: LinkType::ReferenceUnknown
+                    | LinkType::CollapsedUnknown
+                    | LinkType::ShortcutUnknown,
+                ..
+            })
         )
     })
 }

--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -24,15 +24,15 @@ use mdbook::{book, BookItem};
 use polib::catalog::Catalog;
 use polib::message::{Message, MessageMutView, MessageView};
 use polib::metadata::CatalogMetadata;
-use pulldown_cmark::{Event, Tag};
+use pulldown_cmark::{Event, Tag, TagEnd};
 
 /// Strip an optional link from a Markdown string.
 fn strip_link(text: &str) -> String {
     let events = extract_events(text, None)
         .into_iter()
         .filter_map(|(_, event)| match event {
-            Event::Start(Tag::Link(..)) => None,
-            Event::End(Tag::Link(..)) => None,
+            Event::Start(Tag::Link { .. }) => None,
+            Event::End(TagEnd::Link) => None,
             _ => Some((0, event)),
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
The latest version of `pulldown-cmark-to-cmark` now supports `pulldown-cmark`. This should allow us to upgrade both dependencies.

Had to adjust TagEnd handling and change some types to fix the build failures.

Information on breaking changes in `pulldown-cmark` is available [here](https://github.com/pulldown-cmark/pulldown-cmark/releases). Not sure if I am missing anything. I hope that the tests we have are extensive enough to catch any issues.