### PR TITLE
Keep Inline HTML tags in the translated text group while ignoring block level HTML tags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly Rust
+        # TODO: Unpin this after 2024-06-10
         run: rustup default nightly-2024-05-10
 
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,8 +113,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly Rust
-        # TODO: Unpin this after 2024-06-10
-        run: rustup default nightly-2024-05-10
+        run: rustup default nightly
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,7 +113,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly Rust
-        run: rustup default nightly
+        run: rustup default nightly-2024-05-10
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/i18n-helpers/src/gettext.rs
+++ b/i18n-helpers/src/gettext.rs
@@ -245,6 +245,24 @@ mod tests {
     }
 
     #[test]
+    fn test_translate_inline_html() {
+        let catalog = create_catalog(&[("foo <b>bar</b> baz", "FOO <b>BAR</b> BAZ")]);
+        assert_eq!(
+            translate("foo <b>bar</b> baz", &catalog),
+            "FOO <b>BAR</b> BAZ"
+        );
+    }
+
+    #[test]
+    fn test_translate_block_html() {
+        let catalog = create_catalog(&[("foo", "FOO"), ("bar", "BAR")]);
+        assert_eq!(
+            translate("<div>\n\nfoo\n\n</div><div>\n\nbar\n\n</div>", &catalog),
+            "<div>\n\nFOO\n\n</div><div>\n\nBAR\n\n</div>"
+        );
+    }
+
+    #[test]
     fn test_translate_table() {
         let catalog = create_catalog(&[
             ("Types", "TYPES"),

--- a/i18n-helpers/src/normalize.rs
+++ b/i18n-helpers/src/normalize.rs
@@ -461,6 +461,34 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_inline_html() {
+        // Inline tags are kept as is.
+        let catalog = create_catalog(&[("foo <span>bar</span>", "FOO <span>BAR</span>")]);
+        assert_normalized_messages_eq(
+            catalog,
+            &[exact("foo <span>bar</span>", "FOO <span>BAR</span>")],
+        );
+    }
+
+    #[test]
+    fn test_normalize_block_html() {
+        // Block level tags are not translated.
+        let catalog = create_catalog(&[(
+            "<div class=\"warning\">\n\
+            \n\
+            foo\n\
+            \n\
+            </div>",
+            "<div class=\"warning\">\n\
+            \n\
+            FOO\n\
+            \n\
+            </div>",
+        )]);
+        assert_normalized_messages_eq(catalog, &[exact("foo", "FOO")]);
+    }
+
+    #[test]
     fn test_normalize_disappearing_html() {
         // Normalizing "<b>" results in no messages.
         let catalog = create_catalog(&[("<b>", "FOO")]);


### PR DESCRIPTION
Fixes #125 by keeping inline HTML tags in the translation text group but skip block level HTML tags.
This is possible with the upgrade of pulldown-cmark in #183