### PR TITLE
Remove unnecessary strip_link

### DIFF
--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -219,7 +219,7 @@ where
             for (lineno, extracted) in extract_messages(&chapter.content) {
                 let msgid = extracted.message;
                 let source = build_source(&path, lineno, granularity);
-                add_message(catalog, &strip_link(&msgid), &source, &extracted.comment);
+                add_message(catalog, &msgid, &source, &extracted.comment);
             }
 
             // Add the contents for all of the sub-chapters within the
@@ -239,7 +239,7 @@ where
                 for (lineno, extracted) in extract_messages(&content) {
                     let msgid = extracted.message;
                     let source = format!("{}:{}", source.display(), lineno);
-                    add_message(catalog, &strip_link(&msgid), &source, &extracted.comment);
+                    add_message(catalog, &msgid, &source, &extracted.comment);
                 }
             }
         }
@@ -513,7 +513,9 @@ mod tests {
                 "# How to Foo\n\
                  \n\
                  First paragraph.\n\
-                 Same paragraph.\n",
+                 Same paragraph.\n\
+                 \n\
+                 [Link](https://example.com)\n",
             ),
         ])?;
 
@@ -533,6 +535,7 @@ mod tests {
                 ("src/SUMMARY.md:1", "The _Foo_ Chapter"),
                 ("src/foo.md:1", "How to Foo"),
                 ("src/foo.md:3", "First paragraph. Same paragraph."),
+                ("src/foo.md:6", "[Link](https://example.com)"),
             ]
         );
 


### PR DESCRIPTION
`strip_link` seems to remove all links from catalog.
According to the comment, it should be applied to summary only.

https://github.com/google/mdbook-i18n-helpers/blob/71b4cc5d1c0cf0db14f2c264ddccee401b8e36c6/i18n-helpers/src/xgettext.rs#L145-L149

Closes #202 