### PR TITLE
Bump mdbook-i18n-helpers version to 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,7 +681,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-i18n-helpers"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/i18n-helpers/CHANGELOG.md
+++ b/i18n-helpers/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This lists the most important changes between releases of mdbook-i18n-helpers.
 
+## Version 0.3.4 (2024-05-26)
+
+- [#203] : Fix removal of links by @dalance
+
 ## Version 0.3.3 (2024-05-25)
 
 - [#107], [#177]: Support for translator comments by @dyoo
@@ -73,6 +77,7 @@ add [more controls][#76] for this in the future.
 
 First release as a stand-alone crate.
 
+[#203]: https://github.com/google/mdbook-i18n-helpers/pull/203
 [#195]: https://github.com/google/mdbook-i18n-helpers/pull/195
 [#193]: https://github.com/google/mdbook-i18n-helpers/pull/193
 [#179]: https://github.com/google/mdbook-i18n-helpers/pull/179

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-i18n-helpers"
-version = "0.3.3"
+version = "0.3.4"
 authors = ["Martin Geisler <mgeisler@google.com>"]
 categories = ["command-line-utilities", "localization"]
 edition = "2021"


### PR DESCRIPTION
Hotfix release to include changes from https://github.com/google/mdbook-i18n-helpers/pull/203