### PR TITLE
Add i18n-report mode to show diff between two sets of translations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,18 +202,19 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
 dependencies = [
  "anstream",
  "anstyle",
@@ -229,6 +230,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd79504325bf38b10165b02e89b4347300f855f273c4cb30c4a3209e6583275e"
 dependencies = [
  "clap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -461,6 +474,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "humansize"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +499,7 @@ name = "i18n-report"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "polib",
  "tera",
 ]

--- a/i18n-report/Cargo.toml
+++ b/i18n-report/Cargo.toml
@@ -14,5 +14,6 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clap = { version = "4.5.8", features = ["derive"] }
 polib.workspace = true
 tera = { version = "1.20.0", default-features = false }

--- a/i18n-report/README.md
+++ b/i18n-report/README.md
@@ -15,10 +15,16 @@ $ cargo install i18n-report
 
 ## Usage
 
-If your PO files are stored under `po/`:
+To generate a status report for the PO files stored under `po/`:
 
 ```shell
-$ i18n-report report.html po/*.po
+$ i18n-report report report.html po/*.po
+```
+
+To print a diff between two sets of translations stored under `old/` and `new/`:
+
+```shell
+$ i18n-report diff old/ new/
 ```
 
 ## License

--- a/i18n-report/src/main.rs
+++ b/i18n-report/src/main.rs
@@ -22,7 +22,7 @@ use clap::Parser;
 use polib::po_file;
 use stats::MessageStats;
 use std::{
-    fs,
+    fs::{self, read_dir},
     path::{Path, PathBuf},
 };
 use tera::{Context, Tera};
@@ -37,6 +37,12 @@ fn main() -> anyhow::Result<()> {
             translation_files,
         } => {
             report(&report_file, &translation_files)?;
+        }
+        Args::Diff {
+            old_translations,
+            new_translations,
+        } => {
+            diff(&old_translations, &new_translations)?;
         }
     }
 
@@ -53,19 +59,18 @@ enum Args {
         #[arg(id = "language.po")]
         translation_files: Vec<PathBuf>,
     },
+    /// Generate a report showing any difference between two directories of language files.
+    Diff {
+        /// Directory containing the old translation .po files.
+        old_translations: PathBuf,
+        /// Directory containing the new translation .po files.
+        new_translations: PathBuf,
+    },
 }
 
 /// Generates an HTML report about the status of translations in each of the given language files.
 fn report(report_file: &Path, translation_files: &[PathBuf]) -> anyhow::Result<()> {
-    let mut languages = translation_files
-        .iter()
-        .map(|translation| {
-            let catalog = po_file::parse(translation)
-                .with_context(|| format!("Could not parse {:?}", &translation))?;
-            let stats = MessageStats::for_catalog(&catalog);
-            Ok::<_, anyhow::Error>(stats)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut languages = all_stats(translation_files)?;
     languages.sort_by_key(|stats| stats.translated_count);
     languages.reverse();
     let languages = languages
@@ -79,4 +84,90 @@ fn report(report_file: &Path, translation_files: &[PathBuf]) -> anyhow::Result<(
     fs::write(report_file, report)?;
 
     Ok(())
+}
+
+/// Reads each given PO file and returns message stats for each.
+fn all_stats(files: &[PathBuf]) -> anyhow::Result<Vec<MessageStats>> {
+    files
+        .iter()
+        .map(|translation| {
+            let catalog = po_file::parse(translation)
+                .with_context(|| format!("Could not parse {:?}", &translation))?;
+            let stats = MessageStats::for_catalog(&catalog);
+            Ok(stats)
+        })
+        .collect()
+}
+
+/// Prints a report showing any difference between two directories of language files.
+#[allow(clippy::print_stdout)]
+fn diff(
+    old_translations_directory: &Path,
+    new_translations_directory: &Path,
+) -> anyhow::Result<()> {
+    let mut old_translations = all_stats(&po_files(old_translations_directory)?)?;
+    let mut new_translations = all_stats(&po_files(new_translations_directory)?)?;
+    old_translations.sort_by_key(|stats| stats.language.clone());
+    new_translations.sort_by_key(|stats| stats.language.clone());
+
+    if old_translations == new_translations {
+        return Ok(());
+    }
+
+    let mut old_iter = old_translations.iter();
+    let mut new_iter = new_translations.iter();
+    let mut old = old_iter.next();
+    let mut new = new_iter.next();
+    println!("Counts are \"translated (fuzzy, fuzzy untranslated) / total\"");
+    loop {
+        match (old, new) {
+            (None, None) => break,
+            (Some(old_stats), None) => {
+                println!("Removed {}", old_stats);
+                old = old_iter.next();
+            }
+            (None, Some(new_stats)) => {
+                println!("Added {}", new_stats);
+                new = new_iter.next();
+            }
+            (Some(old_stats), Some(new_stats)) => match old_stats.language.cmp(&new_stats.language)
+            {
+                std::cmp::Ordering::Less => {
+                    println!("Removed {}", old_stats);
+                    old = old_iter.next();
+                }
+                std::cmp::Ordering::Greater => {
+                    println!("Added {}", new_stats);
+                    new = new_iter.next();
+                }
+                std::cmp::Ordering::Equal => {
+                    if old_stats != new_stats {
+                        println!("Changed {} -> {}", old_stats, new_stats);
+                    }
+                    old = old_iter.next();
+                    new = new_iter.next();
+                }
+            },
+        }
+    }
+
+    Ok(())
+}
+
+/// Given a directory path, returns the paths of all the `.po` files in it.
+fn po_files(directory: &Path) -> anyhow::Result<Vec<PathBuf>> {
+    read_dir(directory)?
+        .filter_map(|entry| {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(e) => return Some(Err(e.into())),
+            };
+            let path = entry.path();
+            if path.extension()? == "po" {
+                Some(Ok(path))
+            } else {
+                None
+            }
+        })
+        .collect()
 }

--- a/i18n-report/src/stats.rs
+++ b/i18n-report/src/stats.rs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
-
 use polib::catalog::Catalog;
+use std::{
+    collections::BTreeMap,
+    fmt::{self, Display, Formatter},
+};
 use tera::Value;
 
 /// Counts of translation message statuses.
@@ -99,5 +101,20 @@ impl MessageStats {
             }
         }
         stats
+    }
+}
+
+impl Display for MessageStats {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(
+            f,
+            "{}: {} ({}, {}) / {}, creation date {}",
+            self.language,
+            self.translated_count,
+            self.fuzzy_translated_count,
+            self.fuzzy_non_translated_count,
+            self.total(),
+            self.pot_creation_date,
+        )
     }
 }


### PR DESCRIPTION
The report looks like this:

```
Counts are "translated (fuzzy, fuzzy untranslated) / total"
Removed bn: 752 (54, 1) / 3761, creation date 2024-03-03T20:37:57+05:30
Added fo: 568 (178, 1) / 3651, creation date 2024-01-24T13:24:49+01:00
Changed ro: 1032 (2731, 0) / 3763, creation date 2024-05-15T20:58:33+03:00 -> ro: 1018 (2731, 0) / 3749, creation date 2024-05-15T20:58:33+03:00
```

The intention is that this can be used from a GitHub action to show a summary of translation changes on PRs.