### PR TITLE
Advance POT-Creation-Date by 1 minute on normalization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,7 +174,9 @@ checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "wasm-bindgen",
  "windows-targets 0.52.5",
 ]
 
@@ -300,6 +302,18 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "dateparser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2ef451feee09ae5ecd8a02e738bd9adee9266b8fa9b44e22d3ce968d8694238"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -645,6 +659,7 @@ version = "0.3.4"
 dependencies = [
  "anyhow",
  "chrono",
+ "dateparser",
  "mdbook",
  "polib",
  "pretty_assertions",

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 anyhow.workspace = true
 chrono = { version = "0.4.38", default-features = false, features = ["alloc"] }
+dateparser = "0.2.1"
 mdbook.workspace = true
 polib.workspace = true
 pulldown-cmark = { version = "0.11.0", default-features = false, features = ["html"] }

--- a/i18n-helpers/src/normalize.rs
+++ b/i18n-helpers/src/normalize.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::Read;
 
 use crate::{extract_messages, new_cmark_parser, wrap_sources};
+use chrono::Duration;
 use polib::catalog::Catalog;
 use polib::message::{Message, MessageFlags, MessageMutView, MessageView};
 use pulldown_cmark::{Event, LinkType, Tag};
@@ -247,8 +248,17 @@ pub fn normalize(catalog: Catalog) -> anyhow::Result<Catalog> {
                 message.source_mut().push('\n');
                 message.source_mut().push_str(new_message.source());
             }
-            None => new_catalog.append_or_update(new_message),
+            None => new_catalog.append_or_update(new_message)
         }
+    }
+
+    // Increment POT-Creation-Date in metadata by 1 minute to indicate a change in the file.
+    if let Ok(pot_creation_date) = dateparser::parse(&new_catalog.metadata.pot_creation_date) {
+        new_catalog.metadata.pot_creation_date = pot_creation_date
+            .checked_add_signed(Duration::minutes(1))
+            .ok_or(anyhow::Error::msg("could not advance POT-Creation-Date"))?
+            .format("%Y-%m-%d %H:%M%z")
+            .to_string();
     }
 
     Ok(new_catalog)
@@ -565,5 +575,13 @@ mod tests {
                 exact("`()`, ...", "`()`, ..."),
             ],
         );
+    }
+
+    #[test]
+    fn test_normalize_pot_creation_date() {
+        let mut catalog = create_catalog(&[]);
+        catalog.metadata.pot_creation_date = String::from("2008-02-06 16:25+0000");
+        let new_catalog = normalize(catalog).expect("could not advance POT-Creation-Date");
+        assert_eq!(new_catalog.metadata.pot_creation_date, String::from("2008-02-06 16:26+0000"))
     }
 }

--- a/i18n-helpers/src/normalize.rs
+++ b/i18n-helpers/src/normalize.rs
@@ -248,17 +248,19 @@ pub fn normalize(catalog: Catalog) -> anyhow::Result<Catalog> {
                 message.source_mut().push('\n');
                 message.source_mut().push_str(new_message.source());
             }
-            None => new_catalog.append_or_update(new_message)
+            None => new_catalog.append_or_update(new_message),
         }
     }
 
     // Increment POT-Creation-Date in metadata by 1 minute to indicate a change in the file.
+    // Do not change the date if parsing or advancing the date fails.
     if let Ok(pot_creation_date) = dateparser::parse(&new_catalog.metadata.pot_creation_date) {
-        new_catalog.metadata.pot_creation_date = pot_creation_date
-            .checked_add_signed(Duration::minutes(1))
-            .ok_or(anyhow::Error::msg("could not advance POT-Creation-Date"))?
-            .format("%Y-%m-%d %H:%M%z")
-            .to_string();
+        if let Some(new_pot_creation_date) =
+            pot_creation_date.checked_add_signed(Duration::minutes(1))
+        {
+            new_catalog.metadata.pot_creation_date =
+                new_pot_creation_date.format("%Y-%m-%d %H:%M%z").to_string();
+        }
     }
 
     Ok(new_catalog)
@@ -582,6 +584,20 @@ mod tests {
         let mut catalog = create_catalog(&[]);
         catalog.metadata.pot_creation_date = String::from("2008-02-06 16:25+0000");
         let new_catalog = normalize(catalog).expect("could not advance POT-Creation-Date");
-        assert_eq!(new_catalog.metadata.pot_creation_date, String::from("2008-02-06 16:26+0000"))
+        assert_eq!(
+            new_catalog.metadata.pot_creation_date,
+            String::from("2008-02-06 16:26+0000")
+        )
+    }
+    
+    #[test]
+    fn test_normalize_pot_creation_date_parsing_fails() {
+        let mut catalog = create_catalog(&[]);
+        catalog.metadata.pot_creation_date = String::from("not a valid date");
+        let new_catalog = normalize(catalog).expect("could not advance POT-Creation-Date");
+        assert_eq!(
+            new_catalog.metadata.pot_creation_date,
+            String::from("not a valid date")
+        )
     }
 }

--- a/i18n-helpers/src/normalize.rs
+++ b/i18n-helpers/src/normalize.rs
@@ -589,7 +589,7 @@ mod tests {
             String::from("2008-02-06 16:26+0000")
         )
     }
-    
+
     #[test]
     fn test_normalize_pot_creation_date_parsing_fails() {
         let mut catalog = create_catalog(&[]);


### PR DESCRIPTION
Fixes #117.

Advances POT-Creation-Date by 1 minute rather than 1 second as @mgeisler suggested as it seems like the date format does not include seconds for some reason: https://www.gnu.org/software/trans-coord/manual/gnun/html_node/PO-Header.html

```
"POT-Creation-Date: 2008-02-06 16:25-0500\n"
"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
```