### PR TITLE
Make xgettext respect granularity for sub-chapter messages

### DIFF
--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -768,7 +768,7 @@ mod tests {
 
         Ok(())
     }
- 
+
     #[test]
     fn test_split_catalog_nested_directories_depth_1() -> anyhow::Result<()> {
         let (ctx, _tmp) = create_render_context(&[

--- a/i18n-helpers/src/xgettext.rs
+++ b/i18n-helpers/src/xgettext.rs
@@ -235,10 +235,10 @@ where
                     .entry(destination.clone())
                     .or_insert_with(|| Catalog::new(generate_catalog_metadata(ctx)));
 
-                let source = ctx.config.book.src.join(&source);
+                let path = ctx.config.book.src.join(&source);
                 for (lineno, extracted) in extract_messages(&content) {
                     let msgid = extracted.message;
-                    let source = format!("{}:{}", source.display(), lineno);
+                    let source = build_source(&path, lineno, granularity);
                     add_message(catalog, &msgid, &source, &extracted.comment);
                 }
             }


### PR DESCRIPTION
Related to #171.

While trying to refresh the Spanish translation of Comprehensive Rust, @henrif75 noticed that the `messages.pot` file I generated had line numbers that shouldn't be there (see https://github.com/google/comprehensive-rust/issues/2120).

Digging around in the code, I noticed that the `xgettext` code was ignoring the granularity for sub-chapters. This PR fixes that!