### PR TITLE
Lower dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       minor:
         update-types:
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     groups:
       minor:
         update-types:


### PR DESCRIPTION
We are not super dependent on using the latest patch releases of every crate, so a monthly update frequency should be more than enough.


Note that we still get PRs if/when there is a [security update](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval).