### PR TITLE
Pulldown cmark to cmark 17.0.0 upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -966,9 +966,9 @@ checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
 name = "pulldown-cmark-to-cmark"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171b9687038fb417937aee4ce1d0a269897091f05be16660a1e45777533c54b9"
+checksum = "41b27c0d365d60ff3e085007911d73419e5664de48155d558ebfa84d117a5109"
 dependencies = [
  "pulldown-cmark 0.12.1",
 ]

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -19,7 +19,7 @@ dateparser = "0.2.1"
 mdbook.workspace = true
 polib.workspace = true
 pulldown-cmark = { version = "0.12.1", default-features = false, features = ["html"] }
-pulldown-cmark-to-cmark = "16.0.1"
+pulldown-cmark-to-cmark = "17.0.0"
 regex = "1.11"
 semver = "1.0.23"
 serde_json.workspace = true

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -93,27 +93,27 @@ pub fn new_cmark_parser<'input, F: BrokenLinkCallback<'input>>(
 /// );
 /// ```
 pub fn extract_events<'a>(text: &'a str, state: Option<State<'a>>) -> Vec<(usize, Event<'a>)> {
-    // Expand a `[foo]` style link into `[foo][foo]`.
+    // Expand a `[foo]` style links into inline links like `[foo](url)`
     fn expand_shortcut_link(tag: Tag<'_>) -> Tag<'_> {
         match tag {
             Tag::Link {
-                link_type: LinkType::Shortcut,
+                link_type: LinkType::Shortcut | LinkType::Collapsed | LinkType::Reference,
                 dest_url,
                 title,
                 id,
             } => Tag::Link {
-                link_type: LinkType::Reference,
+                link_type: LinkType::Inline,
                 dest_url,
                 title,
                 id,
             },
             Tag::Image {
-                link_type: LinkType::Shortcut,
+                link_type: LinkType::Shortcut | LinkType::Collapsed | LinkType::Reference,
                 dest_url,
                 title,
                 id,
             } => Tag::Image {
-                link_type: LinkType::Reference,
+                link_type: LinkType::Inline,
                 dest_url,
                 title,
                 id,


### PR DESCRIPTION
* Upgrades pulldown-cmark-to-cmark
* Adjust tests for new way reference links are handled

This supersedes https://github.com/google/mdbook-i18n-helpers/pull/233.

Tests had to be adjusted because new version of the library retains more info from reference links. Reference links are no longer replaced with full URLs. We can probably make some manual adjustments to reference link handling in order to retain the old behavior but I think the new way should work better.