### PR TITLE
Export Xgettext as Renderer

### DIFF
--- a/i18n-helpers/src/bin/mdbook-xgettext.rs
+++ b/i18n-helpers/src/bin/mdbook-xgettext.rs
@@ -22,25 +22,12 @@
 //! of Chapter nesting.
 
 use anyhow::Context;
-use mdbook::renderer::RenderContext;
-use mdbook_i18n_helpers::xgettext::create_catalogs;
-use std::{fs, io};
+use mdbook::renderer::{RenderContext, Renderer};
+use mdbook_i18n_helpers::renderers::Xgettext;
+use std::io;
 
 fn main() -> anyhow::Result<()> {
     let ctx = RenderContext::from_json(&mut io::stdin()).context("Parsing stdin")?;
-    fs::create_dir_all(&ctx.destination)
-        .with_context(|| format!("Could not create {}", ctx.destination.display()))?;
-    let catalogs = create_catalogs(&ctx, std::fs::read_to_string).context("Extracting messages")?;
-
-    // Create a template file for each entry with the content from the respective catalog.
-    for (file_path, catalog) in catalogs {
-        let directory_path = file_path.parent().unwrap();
-        fs::create_dir_all(directory_path)
-            .with_context(|| format!("Could not create {}", directory_path.display()))?;
-
-        polib::po_file::write(&catalog, &file_path)
-            .with_context(|| format!("Writing messages to {}", file_path.display()))?;
-    }
-
-    Ok(())
+    let renderer = Xgettext {};
+    renderer.render(&ctx)
 }

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -37,6 +37,7 @@ pub mod directives;
 pub mod gettext;
 pub mod normalize;
 pub mod preprocessors;
+pub mod renderers;
 pub mod xgettext;
 
 /// Re-wrap the sources field of a message.

--- a/i18n-helpers/src/renderers.rs
+++ b/i18n-helpers/src/renderers.rs
@@ -1,0 +1,2 @@
+mod xgettext;
+pub use xgettext::Xgettext;

--- a/i18n-helpers/src/renderers/xgettext.rs
+++ b/i18n-helpers/src/renderers/xgettext.rs
@@ -1,0 +1,32 @@
+use crate::xgettext::create_catalogs;
+use anyhow::Context;
+use mdbook::renderer::{RenderContext, Renderer};
+use std::fs;
+
+/// Renderer for xgettext
+pub struct Xgettext;
+
+impl Renderer for Xgettext {
+    fn name(&self) -> &str {
+        "xgettext"
+    }
+
+    fn render(&self, ctx: &RenderContext) -> anyhow::Result<()> {
+        fs::create_dir_all(&ctx.destination)
+            .with_context(|| format!("Could not create {}", ctx.destination.display()))?;
+        let catalogs =
+            create_catalogs(ctx, std::fs::read_to_string).context("Extracting messages")?;
+
+        // Create a template file for each entry with the content from the respective catalog.
+        for (file_path, catalog) in catalogs {
+            let directory_path = file_path.parent().unwrap();
+            fs::create_dir_all(directory_path)
+                .with_context(|| format!("Could not create {}", directory_path.display()))?;
+
+            polib::po_file::write(&catalog, &file_path)
+                .with_context(|| format!("Writing messages to {}", file_path.display()))?;
+        }
+
+        Ok(())
+    }
+}

--- a/i18n-helpers/src/renderers/xgettext.rs
+++ b/i18n-helpers/src/renderers/xgettext.rs
@@ -19,12 +19,13 @@ impl Renderer for Xgettext {
 
         // Create a template file for each entry with the content from the respective catalog.
         for (file_path, catalog) in catalogs {
-            let directory_path = file_path.parent().unwrap();
+            let dst_path = ctx.destination.join(file_path);
+            let directory_path = dst_path.parent().unwrap();
             fs::create_dir_all(directory_path)
                 .with_context(|| format!("Could not create {}", directory_path.display()))?;
 
-            polib::po_file::write(&catalog, &file_path)
-                .with_context(|| format!("Writing messages to {}", file_path.display()))?;
+            polib::po_file::write(&catalog, &dst_path)
+                .with_context(|| format!("Writing messages to {}", dst_path.display()))?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR exports `Xgettext` as `Renderer`.
By this change, xgettext can be called from other programs as a library.