### PR TITLE
Fix broken tables whose msgstr is a specific type of HTML

### DIFF
--- a/i18n-helpers/src/gettext.rs
+++ b/i18n-helpers/src/gettext.rs
@@ -322,6 +322,34 @@ mod tests {
     }
 
     #[test]
+    fn test_translate_html_in_table() {
+        let catalog = create_catalog(&[
+            ("Icon", "ICON"),
+            ("Description", "DESCRIPTION"),
+            (
+                "<img src=\"some-icon.svg\" alt=\"Some icon.\"/>",
+                "<img src=\"some-icon.svg\" alt=\"SOME ICON.\"/>",
+            ),
+            ("Some description.", "SOME DESCRIPTION."),
+        ]);
+        // The alignment is lost when we generate new Markdown.
+        assert_eq!(
+            translate(
+                "\
+                | Icon                                            | Description       |\n\
+                |-------------------------------------------------|-------------------|\n\
+                | <img src=\"some-icon.svg\" alt=\"Some icon.\"/> | Some description. |",
+                &catalog
+            )
+            .unwrap(),
+            "\
+            |ICON|DESCRIPTION|\n\
+            |----|-----------|\n\
+            |<img src=\"some-icon.svg\" alt=\"SOME ICON.\"/>|SOME DESCRIPTION.|"
+        );
+    }
+
+    #[test]
     fn test_footnote() {
         let catalog = create_catalog(&[
             ("A footnote[^note].", "A FOOTNOTE[^note]."),

--- a/i18n-helpers/src/gettext.rs
+++ b/i18n-helpers/src/gettext.rs
@@ -347,6 +347,24 @@ mod tests {
     }
 
     #[test]
+    fn test_translate_escaped_pipe_in_table() {
+        let catalog = create_catalog(&[("foo\\|bar", "FOO\\|BAR")]);
+        // The alignment is lost when we generate new Markdown.
+        assert_eq!(
+            translate(
+                "\
+                |foo\\|bar|\n\
+                |---------|",
+                &catalog
+            )
+            .unwrap(),
+            "\
+            |FOO\\|BAR|\n\
+            |-------|",
+        );
+    }
+
+    #[test]
     fn test_footnote() {
         let catalog = create_catalog(&[
             ("A footnote[^note].", "A FOOTNOTE[^note]."),

--- a/i18n-helpers/src/gettext.rs
+++ b/i18n-helpers/src/gettext.rs
@@ -326,26 +326,23 @@ mod tests {
         let catalog = create_catalog(&[
             ("Icon", "ICON"),
             ("Description", "DESCRIPTION"),
-            (
-                "<img src=\"some-icon.svg\" alt=\"Some icon.\"/>",
-                "<img src=\"some-icon.svg\" alt=\"SOME ICON.\"/>",
-            ),
+            ("<img src=\"some-icon.svg\"", "<img src=\"some-icon.svg\""),
             ("Some description.", "SOME DESCRIPTION."),
         ]);
         // The alignment is lost when we generate new Markdown.
         assert_eq!(
             translate(
                 "\
-                | Icon                                            | Description       |\n\
-                |-------------------------------------------------|-------------------|\n\
-                | <img src=\"some-icon.svg\" alt=\"Some icon.\"/> | Some description. |",
+                | Icon                         | Description       |\n\
+                |------------------------------|-------------------|\n\
+                | <img src=\"some-icon.svg\"/> | Some description. |",
                 &catalog
             )
             .unwrap(),
             "\
             |ICON|DESCRIPTION|\n\
             |----|-----------|\n\
-            |<img src=\"some-icon.svg\" alt=\"SOME ICON.\"/>|SOME DESCRIPTION.|"
+            |<img src=\"some-icon.svg\"/>|SOME DESCRIPTION.|"
         );
     }
 

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -125,7 +125,7 @@ pub fn extract_events<'a>(text: &'a str, state: Option<State<'a>>) -> Vec<(usize
     }
 
     // Perform some common transformations on the events
-    fn convert_event_common<'a>(event: Event<'a>) -> Event<'a> {
+    fn convert_event_common(event: Event<'_>) -> Event<'_> {
         match event {
             Event::SoftBreak => Event::Text(" ".into()),
             // Shortcut links like "[foo]" end up as "[foo]"

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -144,7 +144,7 @@ pub fn extract_events<'a>(text: &'a str, state: Option<State<'a>>) -> Vec<(usize
         // table, and return the contents of the cell. This matches the behavior of
         // the parser in this case.
         Some(state) if state.in_table_cell => {
-            let text = format!("|{}|\n|-|", text);
+            let text = format!("|{text}|\n|-|");
             new_cmark_parser::<'_, DefaultBrokenLinkCallback>(&text, None)
                 .filter_map(|event| {
                     let event = match event {

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -71,7 +71,7 @@ pub fn new_cmark_parser<'input, F: BrokenLinkCallback<'input>>(
 /// particular:
 ///
 /// - If a code block has started, the text should be parsed
-/// without interpreting special Markdown characters.
+///   without interpreting special Markdown characters.
 /// - In a table cell, the text should be parsed as inlines.
 ///
 /// The events are labeled with the line number where they start in


### PR DESCRIPTION
If an msgstr for a table cell contains HTML that could be parsed as an HTML block if it were put in the top-level, the table is rendered incorrectly. The table row containing the cell gets interrupted in the middle and split into two (or more, if there are more such cells) incomplete rows.

Close #251.