### PR TITLE
Prepare mdboook-i18n-helpers for 0.3.6 release.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,7 +687,7 @@ dependencies = [
 
 [[package]]
 name = "mdbook-i18n-helpers"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/i18n-helpers/CHANGELOG.md
+++ b/i18n-helpers/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This lists the most important changes between releases of mdbook-i18n-helpers.
 
+## Version 0.3.6 (2025-02-25)
+
+- Dependency updates, notably mdbook to 0.4.44 which adds support for Rust 2024
+  edition.
+
 ## Version 0.3.5 (2024-07-23)
 
 - [#208]: Trim dependencies by @klensy

--- a/i18n-helpers/Cargo.toml
+++ b/i18n-helpers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdbook-i18n-helpers"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["Martin Geisler <mgeisler@google.com>"]
 categories = ["command-line-utilities", "localization"]
 edition = "2021"


### PR DESCRIPTION
This is necessary to support Rust 2024 edition.