### PR TITLE
fix char-boundary panic in comment directive parsing

### DIFF
--- a/i18n-helpers/src/directives.rs
+++ b/i18n-helpers/src/directives.rs
@@ -31,13 +31,17 @@ pub fn find(html: &str) -> Option<Directive> {
         (Some("skip"), Some("start")) => Some(Directive::SkipStart),
         (Some("skip"), Some("end")) => Some(Directive::SkipEnd),
         (Some("comment"), _) => {
-            let start_of_comment_offset = std::cmp::min(
-                command.find("comment").unwrap() + "comment".len() + 1,
-                command.len(),
-            );
-            Some(Directive::Comment(
-                command[start_of_comment_offset..].trim().into(),
-            ))
+            // "comment" is ASCII, so this offset is always on a char
+            // boundary. The separator after the keyword may be a multi-byte
+            // Unicode whitespace, so drop it via `chars()` rather than a fixed
+            // byte offset to avoid slicing inside a code point.
+            let after_keyword = command.find("comment").unwrap() + "comment".len();
+            let rest = &command[after_keyword..];
+            let body = match rest.chars().next() {
+                Some(c) if is_delimiter(c) => &rest[c.len_utf8()..],
+                _ => rest,
+            };
+            Some(Directive::Comment(body.trim().into()))
         }
         _ => None,
     }
@@ -166,6 +170,18 @@ mod tests {
         assert!(match find("<!-- i18n:comment -->") {
             Some(Directive::Comment(s)) => {
                 s.is_empty()
+            }
+            _ => false,
+        });
+    }
+
+    #[test]
+    fn test_comment_multibyte_separator() {
+        // A multi-byte Unicode whitespace (here a no-break space) separating
+        // the keyword from the body must not be sliced through.
+        assert!(match find("<!-- i18n:comment\u{a0}hello world! -->") {
+            Some(Directive::Comment(s)) => {
+                s == "hello world!"
             }
             _ => false,
         });


### PR DESCRIPTION
1. The comment directive parser locates the `comment` keyword and skips the keyword length plus one byte to reach the body, assuming the separator after the keyword is a single byte.
2. The tokenizer treats any Unicode whitespace as a separator, so a multi-byte one like U+00A0 makes that byte offset land inside the code point, and `directives::find` panics slicing on a non-char boundary for book content such as `<!-- i18n:comment<NBSP>text -->`. It reaches `mdbook-gettext`/`mdbook-xgettext` through `group_events`.

Step past the separator by its UTF-8 width instead. The group_events fuzzer can reach this path but runs with `-only_ascii=1`, so it never generated the input.