### PR TITLE
guard po_file::parse against panics on malformed input

### DIFF
--- a/i18n-helpers/src/bin/mdbook-i18n-normalize.rs
+++ b/i18n-helpers/src/bin/mdbook-i18n-normalize.rs
@@ -13,7 +13,7 @@
 use std::path::Path;
 
 use anyhow::{bail, Context};
-use mdbook_i18n_helpers::normalize::normalize;
+use mdbook_i18n_helpers::{normalize::normalize, parse_catalog};
 use polib::po_file;
 
 fn main() -> anyhow::Result<()> {
@@ -24,7 +24,7 @@ fn main() -> anyhow::Result<()> {
         [] => unreachable!(),
     };
 
-    let catalog = po_file::parse(Path::new(input))
+    let catalog = parse_catalog(Path::new(input))
         .with_context(|| format!("Could not parse {:?}", &output))?;
     let normalized = normalize(catalog)?;
     po_file::write_to_file(&normalized, Path::new(output))

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -47,6 +47,8 @@ pub mod xgettext;
 /// `msgid` line whose value is not wrapped in quotes) instead of returning an
 /// error. Guard the call so an invalid translation file is reported as a parse
 /// error rather than aborting the process.
+///
+/// Remove when https://github.com/BrettDong/polib/issues/25 is closed.
 pub fn parse_catalog(path: &std::path::Path) -> anyhow::Result<Catalog> {
     match std::panic::catch_unwind(|| polib::po_file::parse(path)) {
         Ok(result) => result.map_err(|err| anyhow::anyhow!("{err}")),

--- a/i18n-helpers/src/lib.rs
+++ b/i18n-helpers/src/lib.rs
@@ -41,6 +41,19 @@ pub mod preprocessors;
 pub mod renderers;
 pub mod xgettext;
 
+/// Parse the PO/POT file at `path` into a catalog.
+///
+/// `polib::po_file::parse` panics on some malformed input (for example a
+/// `msgid` line whose value is not wrapped in quotes) instead of returning an
+/// error. Guard the call so an invalid translation file is reported as a parse
+/// error rather than aborting the process.
+pub fn parse_catalog(path: &std::path::Path) -> anyhow::Result<Catalog> {
+    match std::panic::catch_unwind(|| polib::po_file::parse(path)) {
+        Ok(result) => result.map_err(|err| anyhow::anyhow!("{err}")),
+        Err(_) => Err(anyhow::anyhow!("{path:?} is not a valid PO file")),
+    }
+}
+
 /// Re-wrap the sources field of a message.
 ///
 /// This function tries to wrap the `file:lineno` pairs so they look
@@ -997,6 +1010,34 @@ mod tests {
     use pulldown_cmark::Event::*;
     use pulldown_cmark::HeadingLevel::*;
     use pulldown_cmark::Tag::*;
+
+    #[test]
+    fn parse_catalog_reads_valid_po() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("valid.po");
+        std::fs::write(
+            &path,
+            "msgid \"\"\n\
+             msgstr \"\"\n\
+             \"Content-Type: text/plain; charset=UTF-8\\n\"\n\
+             \n\
+             msgid \"Hello\"\n\
+             msgstr \"Bonjour\"\n",
+        )
+        .unwrap();
+        let catalog = parse_catalog(&path).unwrap();
+        assert_eq!(catalog.messages().count(), 1);
+    }
+
+    #[test]
+    fn parse_catalog_reports_malformed_po_as_error() {
+        // An unquoted `msgid` value makes polib panic while slicing off the
+        // surrounding quotes; it must surface as an error instead of crashing.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("malformed.po");
+        std::fs::write(&path, "msgid x\n").unwrap();
+        assert!(parse_catalog(&path).is_err());
+    }
 
     /// Extract messages in `document`, assert they match `expected`.
     #[track_caller]

--- a/i18n-helpers/src/preprocessors/gettext.rs
+++ b/i18n-helpers/src/preprocessors/gettext.rs
@@ -16,7 +16,6 @@ use crate::gettext::{add_stripped_summary_translations, translate_book};
 use anyhow::{anyhow, Context};
 use mdbook_preprocessor::{Preprocessor, PreprocessorContext};
 use polib::catalog::Catalog;
-use polib::po_file;
 use std::path::PathBuf;
 
 /// Check whether the book should be transalted.
@@ -56,8 +55,7 @@ fn get_catalog_path(ctx: &PreprocessorContext) -> anyhow::Result<PathBuf> {
 fn load_catalog(ctx: &PreprocessorContext) -> anyhow::Result<Catalog> {
     let path = get_catalog_path(ctx)?;
 
-    let catalog = po_file::parse(&path)
-        .map_err(|err| anyhow!("{err}"))
+    let catalog = crate::parse_catalog(&path)
         .with_context(|| format!("Could not parse {path:?} as PO file"))?;
 
     Ok(catalog)

--- a/i18n-report/src/main.rs
+++ b/i18n-report/src/main.rs
@@ -106,6 +106,8 @@ fn all_stats(files: &[PathBuf]) -> anyhow::Result<Vec<MessageStats>> {
 /// `msgid` line whose value is not wrapped in quotes) instead of returning an
 /// error. Guard the call so an invalid file is reported as an error rather
 /// than aborting the process.
+///
+/// Remove when https://github.com/BrettDong/polib/issues/25 is closed.
 fn parse_catalog(path: &Path) -> anyhow::Result<Catalog> {
     match std::panic::catch_unwind(|| po_file::parse(path)) {
         Ok(result) => result.map_err(|err| anyhow::anyhow!("{err}")),

--- a/i18n-report/src/main.rs
+++ b/i18n-report/src/main.rs
@@ -19,6 +19,7 @@ mod stats;
 
 use anyhow::Context as _;
 use clap::Parser;
+use polib::catalog::Catalog;
 use polib::po_file;
 use stats::MessageStats;
 use std::{
@@ -91,12 +92,25 @@ fn all_stats(files: &[PathBuf]) -> anyhow::Result<Vec<MessageStats>> {
     files
         .iter()
         .map(|translation| {
-            let catalog = po_file::parse(translation)
+            let catalog = parse_catalog(translation)
                 .with_context(|| format!("Could not parse {:?}", &translation))?;
             let stats = MessageStats::for_catalog(&catalog);
             Ok(stats)
         })
         .collect()
+}
+
+/// Parse the PO file at `path`.
+///
+/// `polib::po_file::parse` panics on some malformed input (for example a
+/// `msgid` line whose value is not wrapped in quotes) instead of returning an
+/// error. Guard the call so an invalid file is reported as an error rather
+/// than aborting the process.
+fn parse_catalog(path: &Path) -> anyhow::Result<Catalog> {
+    match std::panic::catch_unwind(|| po_file::parse(path)) {
+        Ok(result) => result.map_err(|err| anyhow::anyhow!("{err}")),
+        Err(_) => Err(anyhow::anyhow!("{path:?} is not a valid PO file")),
+    }
 }
 
 /// Prints a report showing any difference between two directories of language files.


### PR DESCRIPTION
polib panics instead of returning an error on some malformed PO lines (an unquoted `msgid` value, a bare `"` continuation), so a bad translation file aborts the whole run instead of failing gracefully.
- the gettext preprocessor and mdbook-i18n-normalize parse translator-supplied PO files and already `with_context` the call, expecting an error not a panic
- added `parse_catalog` to catch the panic and return that parse error instead
- routed the three `po_file::parse` sites (preprocessor, normalizer, i18n-report) through it

Repro: `printf 'msgid x\n' > bad.po; mdbook-i18n-normalize bad.po out.po` aborts before this, now reports a parse error.