### PR TITLE
fuzz the source field in the normalize target

### DIFF
--- a/fuzz/fuzz_targets/normalize.rs
+++ b/fuzz/fuzz_targets/normalize.rs
@@ -2,9 +2,9 @@
 
 use libfuzzer_sys::fuzz_target;
 use mdbook_i18n_helpers::normalize::normalize;
-use mdbook_i18n_helpers_fuzz::create_catalog;
+use mdbook_i18n_helpers_fuzz::create_catalog_with_sources;
 
-fuzz_target!(|translations: Vec<(&str, &str)>| {
-    let catalog = create_catalog(translations);
+fuzz_target!(|entries: Vec<(&str, &str, &str)>| {
+    let catalog = create_catalog_with_sources(entries);
     let _ = normalize(catalog);
 });

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -19,6 +19,28 @@ pub fn create_catalog(translations: Vec<(&str, &str)>) -> Catalog {
     catalog
 }
 
+/// Generate a random Catalog whose `#:` source field is also fuzzed.
+///
+/// `create_catalog` pins every source to `foo.md:{idx}`, so the source
+/// parsing in `normalize` (path extraction, line-number parsing, the
+/// working-directory containment check, and per-paragraph source
+/// recomputation) never sees hostile input. Feeding the source through
+/// `arbitrary` exercises that path with things like multi-reference
+/// sources, out-of-range line numbers, and paths that try to leave the
+/// current directory.
+pub fn create_catalog_with_sources(entries: Vec<(&str, &str, &str)>) -> Catalog {
+    let mut catalog = Catalog::new(CatalogMetadata::new());
+    for (source, msgid, msgstr) in entries {
+        let message = Message::build_singular()
+            .with_source(String::from(source))
+            .with_msgid(String::from(msgid))
+            .with_msgstr(String::from(msgstr))
+            .done();
+        catalog.append_or_update(message);
+    }
+    catalog
+}
+
 /// Generate a random Book for fuzzing.
 pub fn create_book(book_items: Vec<BookItem>) -> Book {
     let mut book = Book::new();


### PR DESCRIPTION
The normalize fuzz target pins every message source to `foo.md:{idx}`, so the source handling in `normalize` is never reached:
- `parse_source`, `is_within_current_dir` and `compute_source` only ever run on a well-formed `path:lineno`
- that source path is where the line-number overflow, the read of a file outside the working directory, and the multi-source source-map key panic all sat
- switched the target to `(source, msgid, msgstr)` triples so `arbitrary` drives the `#:` source per message

Test-only, no library change, clean over a few million runs on the current tree.